### PR TITLE
feat: migrate pages to theme tokens and add dark/light toggle

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -78,7 +78,7 @@ export default function App() {
   // ========================================
   
   return (
-    <div className="relative min-h-screen bg-black overflow-hidden">
+    <div className="relative min-h-screen bg-crt-base overflow-hidden">
       <ParallaxBackground panState={panState}>
         
         <PanStage 
@@ -95,7 +95,7 @@ export default function App() {
               <TVShell className="w-full h-full cursor-pointer">
                 <div className="h-full flex items-center justify-center">
                   <StaticNoise intensity={1} />
-                  <div className="text-white font-semibold text-center text-sm sm:text-base">
+                  <div className="text-crt-text font-semibold text-center text-sm sm:text-base">
                     {tv.title}
                   </div>
                 </div>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2,6 +2,7 @@ import { useEffect, useMemo, useRef, useState } from "react";
 import PanStage, { type PanStageRef } from "./components/PanStage";
 import ParallaxBackground from "./components/ParallaxBackground";
 import StaticNoise from "./components/StaticNoise";
+import ThemeToggle from "./components/ThemeToggle";
 import TVShell from "./components/TVShell";
 import TVZoomOverlay from "./components/TVZoomOverlay";
 import Contact from "./pages/Contact";
@@ -79,6 +80,7 @@ export default function App() {
   
   return (
     <div className="relative min-h-screen bg-crt-base overflow-hidden">
+      <ThemeToggle />
       <ParallaxBackground panState={panState}>
         
         <PanStage 

--- a/src/components/CRTButton.tsx
+++ b/src/components/CRTButton.tsx
@@ -13,7 +13,8 @@ interface CRTButtonProps extends Omit<ButtonHTMLAttributes<HTMLButtonElement>, '
 }
 
 /**
- * CRTButton - Button component with nostalgic CRT TV-themed hover and click animations
+ * CRTButton - Button component with nostalgic CRT TV-themed hover and click animations.
+ * Uses theme tokens for colors so variants adapt to dark/light mode.
  */
 export default function CRTButton({ 
   children, 
@@ -31,17 +32,17 @@ export default function CRTButton({
     lg: 'px-6 py-3 text-base sm:text-lg'
   };
 
-  // Color variants
+  // Color variants using theme tokens
   const variantClasses: Record<ButtonVariant, string> = {
-    primary: 'bg-cyan-600 hover:bg-cyan-700 text-white',
-    secondary: 'bg-transparent border border-gray-600 hover:border-gray-500 text-white',
-    ghost: 'bg-transparent hover:bg-gray-800/30 text-white'
+    primary: 'bg-crt-accent-muted hover:bg-crt-accent-deep text-crt-text',
+    secondary: 'bg-transparent border border-crt-border-secondary hover:border-crt-border text-crt-text',
+    ghost: 'bg-transparent hover:bg-crt-surface-secondary/30 text-crt-text'
   };
 
   const baseClasses = `
     font-medium rounded-lg transition-all duration-200 cursor-pointer
     relative overflow-hidden group
-    focus:outline-none focus:ring-2 focus:ring-cyan-400/50
+    focus:outline-none focus:ring-2 focus:ring-crt-accent/50
     disabled:opacity-50 disabled:cursor-not-allowed
     ${sizeClasses[size]}
     ${variantClasses[variant]}
@@ -99,8 +100,8 @@ export default function CRTButton({
               0deg,
               transparent 0px,
               transparent 2px,
-              rgba(255,255,255,0.1) 2px,
-              rgba(255,255,255,0.1) 3px
+              rgb(var(--crt-scanline-color) / 0.1) 2px,
+              rgb(var(--crt-scanline-color) / 0.1) 3px
             )`
           }}
         />

--- a/src/components/CRTScanlines.tsx
+++ b/src/components/CRTScanlines.tsx
@@ -6,7 +6,8 @@ interface CRTScanlinesProps {
 }
 
 /**
- * CRTScanlines - Horizontal scanlines effect that mimics CRT display technology
+ * CRTScanlines - Horizontal scanlines effect that mimics CRT display technology.
+ * Uses --crt-scanline-color token so lines adapt to dark/light theme.
  */
 export default function CRTScanlines({ 
   opacity = 0.2, 
@@ -23,8 +24,8 @@ export default function CRTScanlines({
           0deg,
           transparent 0px,
           transparent ${lineSpacing}px,
-          rgba(255,255,255,0.03) ${lineSpacing}px,
-          rgba(255,255,255,0.03) ${lineHeight}px
+          rgb(var(--crt-scanline-color) / 0.03) ${lineSpacing}px,
+          rgb(var(--crt-scanline-color) / 0.03) ${lineHeight}px
         )`
       }}
     />

--- a/src/components/CRTVignette.tsx
+++ b/src/components/CRTVignette.tsx
@@ -5,7 +5,8 @@ interface CRTVignetteProps {
 }
 
 /**
- * CRTVignette - Subtle vignette effect that mimics CRT monitor darkening at edges
+ * CRTVignette - Subtle vignette effect that mimics CRT monitor darkening at edges.
+ * Uses --crt-vignette-color token (always dark, even in light mode).
  */
 export default function CRTVignette({ 
   intensity = 0.3, 
@@ -16,7 +17,7 @@ export default function CRTVignette({
     <div 
       className={`absolute inset-0 pointer-events-none ${className}`}
       style={{
-        background: `radial-gradient(circle at center, transparent ${innerRadius}%, rgba(0,0,0,${intensity}) 100%)`
+        background: `radial-gradient(circle at center, transparent ${innerRadius}%, rgb(var(--crt-vignette-color) / ${intensity}) 100%)`
       }}
     />
   );

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -5,6 +5,10 @@ interface NavbarProps {
   onClose?: () => void;
 }
 
+/**
+ * Navbar - Top bar overlay inside TVZoomOverlay with title and close button.
+ * Uses theme tokens for gradient background and text colors.
+ */
 export default function Navbar({ title, onClose }: NavbarProps) {
   const handleMouseEnter = (e: MouseEvent<HTMLButtonElement>) => {
     e.currentTarget.style.filter = 'contrast(1.1) brightness(1.1)';
@@ -22,13 +26,16 @@ export default function Navbar({ title, onClose }: NavbarProps) {
   };
 
   return (
-    <div className="absolute top-0 left-0 right-0 z-10 flex items-center justify-between p-4 bg-gradient-to-b from-black/60 to-transparent pointer-events-none">
-      <div className="text-white font-semibold text-lg tracking-wide pointer-events-auto">
+    <div
+      className="absolute top-0 left-0 right-0 z-10 flex items-center justify-between p-4 pointer-events-none"
+      style={{ background: "linear-gradient(to bottom, rgb(var(--crt-bg-overlay) / 0.6), transparent)" }}
+    >
+      <div className="text-crt-text font-semibold text-lg tracking-wide pointer-events-auto">
         {title}
       </div>
       <button
         onClick={onClose}
-        className="text-white/80 hover:text-white transition-all duration-200 pointer-events-auto focus:outline-none focus:ring-2 focus:ring-white/50 rounded p-1 cursor-pointer group relative overflow-hidden"
+        className="text-crt-text/80 hover:text-crt-text transition-all duration-200 pointer-events-auto focus:outline-none focus:ring-2 focus:ring-crt-text/50 rounded p-1 cursor-pointer group relative overflow-hidden"
         aria-label="Close"
         style={{
           filter: 'none',

--- a/src/components/StaticNoise.tsx
+++ b/src/components/StaticNoise.tsx
@@ -3,6 +3,10 @@ interface StaticNoiseProps {
   className?: string;
 }
 
+/**
+ * StaticNoise - Animated TV static with fizz and noise layers.
+ * Uses --crt-noise-light/dark tokens so noise adapts to theme.
+ */
 export default function StaticNoise({ intensity = 1, className = "" }: StaticNoiseProps) {
   return (
     <div className={`absolute inset-0 pointer-events-none ${className}`}>
@@ -12,7 +16,7 @@ export default function StaticNoise({ intensity = 1, className = "" }: StaticNoi
         style={{
           opacity: 0.7 * intensity,
           background:
-            "repeating-conic-gradient(from 0deg, rgba(255,255,255,0.04) 0deg 10deg, rgba(0,0,0,0.06) 10deg 20deg)",
+            "repeating-conic-gradient(from 0deg, rgb(var(--crt-noise-light) / 0.04) 0deg 10deg, rgb(var(--crt-noise-dark) / 0.06) 10deg 20deg)",
         }}
       />
       {/* CRT scanline noise */}
@@ -21,7 +25,7 @@ export default function StaticNoise({ intensity = 1, className = "" }: StaticNoi
         style={{
           opacity: 0.3 * intensity,
           background:
-            "repeating-linear-gradient(180deg, rgba(255,255,255,0.09) 0px, rgba(255,255,255,0.09) 2px, transparent 2px, transparent 4px)",
+            "repeating-linear-gradient(180deg, rgb(var(--crt-noise-light) / 0.09) 0px, rgb(var(--crt-noise-light) / 0.09) 2px, transparent 2px, transparent 4px)",
         }}
       />
       <style>{`

--- a/src/components/TVGrid.tsx
+++ b/src/components/TVGrid.tsx
@@ -31,7 +31,7 @@ export default function TVGrid({
         >
           <TVShell className="w-full aspect-[4/3]">
             <div className="h-full flex items-center justify-center">
-              <div className="text-white font-semibold text-center text-sm sm:text-base">
+              <div className="text-crt-text font-semibold text-center text-sm sm:text-base">
                 {item.title}
               </div>
             </div>

--- a/src/components/TVShell.tsx
+++ b/src/components/TVShell.tsx
@@ -8,6 +8,10 @@ interface TVShellProps {
   frameClassName?: string;
 }
 
+/**
+ * TVShell - The physical CRT television hardware: plastic body, bezel, screen, vents, indicators.
+ * All colors use theme tokens so the shell adapts to dark/light mode.
+ */
 export default function TVShell({
   children,
   className = "",
@@ -18,15 +22,24 @@ export default function TVShell({
   return (
     <div className={`relative ${className}`}>
       {/* Outer CRT body */}
-      <div className={`relative h-full rounded-[18px] shadow-2xl ${frameClassName} bg-zinc-800/90 border border-zinc-900/60 overflow-hidden`}> 
+      <div className={`relative h-full rounded-[18px] shadow-2xl ${frameClassName} bg-crt-shell border border-crt-border-subtle overflow-hidden`}> 
         {/* Painted plastic shell thickness */}
         <div className="p-3 sm:p-4 h-full">
           <div className="flex items-stretch gap-3 h-full">
             {/* Screen with bezel */}
-            <div className="relative flex-1 rounded-[14px] bg-zinc-950 border-8 border-zinc-900/80 shadow-[inset_0_0_40px_rgba(0,0,0,0.7)] overflow-hidden" data-pan-target>
+            <div
+              className="relative flex-1 rounded-[14px] bg-crt-shell-screen overflow-hidden"
+              style={{
+                borderWidth: "8px",
+                borderStyle: "solid",
+                borderColor: "rgb(var(--crt-shell-bezel) / 0.8)",
+                boxShadow: "inset 0 0 40px rgb(var(--crt-vignette-color) / 0.7)",
+              }}
+              data-pan-target
+            >
               {/* Actual screen content */}
               <div 
-                className="relative w-full h-full bg-black"
+                className="relative w-full h-full bg-crt-shell-screen"
                 style={{ filter: `brightness(${brightness})`}}
               >
                 {children}
@@ -36,7 +49,7 @@ export default function TVShell({
               <div
                 className="pointer-events-none absolute inset-0"
                 style={{
-                  background: "radial-gradient(120% 100% at 50% 50%, rgba(255,255,255,0.18), rgba(0,0,0,0) 60%)",
+                  background: "radial-gradient(120% 100% at 50% 50%, rgb(var(--crt-glow-color) / 0.18), rgb(var(--crt-glow-color) / 0) 60%)",
                   mixBlendMode: "screen",
                   opacity: 0.6,
                 }}
@@ -46,7 +59,7 @@ export default function TVShell({
               <div
                 className="pointer-events-none absolute inset-0"
                 style={{
-                  background: "radial-gradient(120% 100% at 50% 50%, rgba(255,255,255,0.66), rgba(0,0,0,0.15) 60%, rgba(0,0,0,0.65) 100%)",
+                  background: "radial-gradient(120% 100% at 50% 50%, rgb(var(--crt-glow-color) / 0.66), rgb(var(--crt-vignette-color) / 0.15) 60%, rgb(var(--crt-vignette-color) / 0.65) 100%)",
                   mixBlendMode: "overlay",
                   opacity: .9 * intensity,
                 }}
@@ -56,13 +69,16 @@ export default function TVShell({
               <div
                 className="pointer-events-none absolute inset-0"
                 style={{
-                  background: "repeating-linear-gradient(180deg, rgba(255,255,255,0.04) 0px, rgba(255,255,255,0.04) 1px, transparent 2px, transparent 3px)",
+                  background: "repeating-linear-gradient(180deg, rgb(var(--crt-scanline-color) / 0.04) 0px, rgb(var(--crt-scanline-color) / 0.04) 1px, transparent 2px, transparent 3px)",
                   opacity: .2 * intensity,
                 }}
               />
 
               {/* Bloom line */}
-              <div className="pointer-events-none absolute inset-x-0 top-12 h-[2px] bg-white/10 blur-[2px]"/>
+              <div
+                className="pointer-events-none absolute inset-x-0 top-12 h-[2px] blur-[2px]"
+                style={{ backgroundColor: "rgb(var(--crt-glow-color) / 0.1)" }}
+              />
 
             </div>
 
@@ -71,20 +87,33 @@ export default function TVShell({
               {/* Right-edge vents */}
               <div className="absolute right-1 top-4 bottom-4 flex flex-col justify-between">
                 {Array.from({length: 7}).map((_, i) => (
-                  <div key={i} className="w-[3px] h-3 bg-zinc-700/80 rounded-sm"/>
+                  <div key={i} className="w-[3px] h-3 bg-crt-shell-detail rounded-sm" style={{ opacity: 0.8 }} />
                 ))}
               </div>
 
               {/* Bottom-edge flush indicators */}
               <div className="absolute inset-x-6 bottom-1 flex items-center justify-center gap-2">
                 {Array.from({length: 5}).map((_, i) => (
-                  <div key={i} className="w-2 h-2 rounded-full bg-zinc-400/90 ring-1 ring-zinc-600"/>
+                  <div
+                    key={i}
+                    className="w-2 h-2 rounded-full bg-crt-shell-indicator"
+                    style={{
+                      opacity: 0.9,
+                      boxShadow: "0 0 0 1px rgb(var(--crt-shell-detail))",
+                    }}
+                  />
                 ))}
               </div>
 
               {/* Bezel bevel highlights */}
-              <div className="absolute inset-x-0 top-0 h-3 bg-gradient-to-b from-white/10 to-transparent"/>
-              <div className="absolute inset-x-0 bottom-0 h-3 bg-gradient-to-t from-black/40 to-transparent"/>
+              <div
+                className="absolute inset-x-0 top-0 h-3"
+                style={{ background: "linear-gradient(to bottom, rgb(var(--crt-glow-color) / 0.1), transparent)" }}
+              />
+              <div
+                className="absolute inset-x-0 bottom-0 h-3"
+                style={{ background: "linear-gradient(to top, rgb(var(--crt-vignette-color) / 0.4), transparent)" }}
+              />
             </div>
           </div>
         </div>

--- a/src/components/TVZoomOverlay.tsx
+++ b/src/components/TVZoomOverlay.tsx
@@ -16,7 +16,8 @@ interface TVZoomOverlayProps {
 }
 
 /**
- * TVZoomOverlay - True full-screen overlay that displays TV content with CRT effects
+ * TVZoomOverlay - True full-screen overlay that displays TV content with CRT effects.
+ * Uses theme tokens for background, glow, and noise colors.
  */
 export default function TVZoomOverlay({ selectedItem, onClose, children }: TVZoomOverlayProps) {
   // ========================================
@@ -74,7 +75,8 @@ export default function TVZoomOverlay({ selectedItem, onClose, children }: TVZoo
     <AnimatePresence>
       {selectedItem && (
         <motion.div 
-          className="fixed inset-0 z-40 flex items-center justify-center bg-black/60"
+          className="fixed inset-0 z-40 flex items-center justify-center"
+          style={{ backgroundColor: "rgb(var(--crt-bg-overlay) / 0.6)" }}
           initial={{ opacity: 0 }} 
           animate={{ opacity: 1 }} 
           transition={{ duration: 0 }} 
@@ -83,7 +85,7 @@ export default function TVZoomOverlay({ selectedItem, onClose, children }: TVZoo
         >
           {/* Full-screen content container with CRT effects */}
           <motion.div 
-            className="w-full h-full bg-black relative overflow-hidden" 
+            className="w-full h-full bg-crt-base relative overflow-hidden" 
             onClick={(e) => e.stopPropagation()}
           >
             {/* CRT Effects */}
@@ -132,8 +134,8 @@ export default function TVZoomOverlay({ selectedItem, onClose, children }: TVZoo
                       <div
                         className="pointer-events-none absolute inset-x-0 h-8 -top-8"
                         style={{
-                          background: "linear-gradient(to bottom, rgba(255,255,255,0.15), rgba(255,255,255,0.05), transparent)",
-                          boxShadow: "0 0 20px rgba(255,255,255,0.3)",
+                          background: "linear-gradient(to bottom, rgb(var(--crt-glow-color) / 0.15), rgb(var(--crt-glow-color) / 0.05), transparent)",
+                          boxShadow: "0 0 20px rgb(var(--crt-glow-color) / 0.3)",
                           mixBlendMode: "screen",
                           animation: "sweepLine 0.4s linear forwards",
                         }}
@@ -148,15 +150,15 @@ export default function TVZoomOverlay({ selectedItem, onClose, children }: TVZoo
                           background: `
                             repeating-linear-gradient(
                               0deg,
-                              rgba(255,255,255,0.02) 0px,
-                              rgba(0,0,0,0.02) 1px,
+                              rgb(var(--crt-noise-light) / 0.02) 0px,
+                              rgb(var(--crt-noise-dark) / 0.02) 1px,
                               transparent 2px,
                               transparent 3px
                             ),
                             repeating-linear-gradient(
                               90deg,
-                              rgba(255,255,255,0.01) 0px,
-                              rgba(0,0,0,0.01) 1px,
+                              rgb(var(--crt-noise-light) / 0.01) 0px,
+                              rgb(var(--crt-noise-dark) / 0.01) 1px,
                               transparent 2px,
                               transparent 4px
                             )

--- a/src/components/ThemeToggle.tsx
+++ b/src/components/ThemeToggle.tsx
@@ -1,0 +1,61 @@
+import { useTheme } from "../hooks/useTheme";
+
+/**
+ * ThemeToggle - CRT-styled dark/light mode switch.
+ * Rendered as a physical toggle knob that matches the TV aesthetic.
+ */
+export default function ThemeToggle() {
+  const { theme, toggleTheme } = useTheme();
+  const isDark = theme === "dark";
+
+  return (
+    <button
+      onClick={toggleTheme}
+      className="fixed bottom-4 right-4 z-50 group cursor-pointer"
+      aria-label={`Switch to ${isDark ? "light" : "dark"} mode`}
+      title={`Switch to ${isDark ? "light" : "dark"} mode`}
+    >
+      {/* Outer knob housing */}
+      <div className="relative w-12 h-12 rounded-full bg-crt-surface-secondary border-2 border-crt-border shadow-lg transition-all duration-300 group-hover:border-crt-accent/50 group-hover:shadow-crt-accent/20 group-active:scale-95">
+        {/* Inner indicator */}
+        <div className="absolute inset-2 rounded-full flex items-center justify-center transition-all duration-300">
+          {/* Sun icon (light mode) */}
+          <svg
+            className={`w-5 h-5 absolute transition-all duration-300 ${isDark ? "opacity-0 rotate-90 scale-0" : "opacity-100 rotate-0 scale-100"}`}
+            fill="none"
+            stroke="rgb(var(--crt-accent-primary))"
+            strokeWidth="2"
+            viewBox="0 0 24 24"
+          >
+            <circle cx="12" cy="12" r="5" />
+            <path d="M12 1v2M12 21v2M4.22 4.22l1.42 1.42M18.36 18.36l1.42 1.42M1 12h2M21 12h2M4.22 19.78l1.42-1.42M18.36 5.64l1.42-1.42" />
+          </svg>
+          {/* Moon icon (dark mode) */}
+          <svg
+            className={`w-5 h-5 absolute transition-all duration-300 ${isDark ? "opacity-100 rotate-0 scale-100" : "opacity-0 -rotate-90 scale-0"}`}
+            fill="none"
+            stroke="rgb(var(--crt-accent-primary))"
+            strokeWidth="2"
+            viewBox="0 0 24 24"
+          >
+            <path d="M21 12.79A9 9 0 1111.21 3 7 7 0 0021 12.79z" />
+          </svg>
+        </div>
+
+        {/* CRT scanline overlay on hover */}
+        <div
+          className="absolute inset-0 rounded-full opacity-0 group-hover:opacity-30 transition-opacity duration-200 pointer-events-none overflow-hidden"
+          style={{
+            background: `repeating-linear-gradient(
+              0deg,
+              transparent 0px,
+              transparent 2px,
+              rgb(var(--crt-scanline-color) / 0.08) 2px,
+              rgb(var(--crt-scanline-color) / 0.08) 3px
+            )`
+          }}
+        />
+      </div>
+    </button>
+  );
+}

--- a/src/components/portfolio/DemoChannel.tsx
+++ b/src/components/portfolio/DemoChannel.tsx
@@ -5,6 +5,10 @@ interface DemoChannelProps {
   project: Project;
 }
 
+/**
+ * DemoChannel - Demo tab content with video/image player and tech tags.
+ * Uses theme tokens for backgrounds, text, and accent colors.
+ */
 export default function DemoChannel({ project }: DemoChannelProps) {
   return (
     <motion.div
@@ -16,12 +20,12 @@ export default function DemoChannel({ project }: DemoChannelProps) {
     >
       <div className="max-w-4xl w-full">
         <div className="text-center mb-8">
-          <h2 className="text-3xl font-bold text-cyan-400 mb-2">{project.title}</h2>
-          <p className="text-gray-400 text-lg">{project.category}</p>
+          <h2 className="text-3xl font-bold text-crt-accent mb-2">{project.title}</h2>
+          <p className="text-crt-text-tertiary text-lg">{project.category}</p>
         </div>
         
         {/* Demo Media */}
-        <div className="relative bg-gray-900 rounded-lg overflow-hidden aspect-video mb-6">
+        <div className="relative bg-crt-surface-primary rounded-lg overflow-hidden aspect-video mb-6">
           {project.demo.type === 'video' ? (
             <video
               src={project.demo.src}
@@ -49,11 +53,11 @@ export default function DemoChannel({ project }: DemoChannelProps) {
           
           {/* Overlay for placeholder only */}
           {project.demo.src.includes('placeholder') && (
-            <div className="absolute inset-0 flex items-center justify-center bg-gray-800">
+            <div className="absolute inset-0 flex items-center justify-center bg-crt-surface-secondary">
               <div className="text-center">
                 <div className="text-6xl mb-4">📹</div>
-                <p className="text-gray-400">Demo video coming soon</p>
-                <p className="text-sm text-gray-500 mt-2">{project.demo.alt}</p>
+                <p className="text-crt-text-tertiary">Demo video coming soon</p>
+                <p className="text-sm text-crt-text-muted mt-2">{project.demo.alt}</p>
               </div>
             </div>
           )}
@@ -64,7 +68,7 @@ export default function DemoChannel({ project }: DemoChannelProps) {
           {project.tech.map((tech) => (
             <span
               key={tech}
-              className="px-3 py-1 bg-cyan-400/20 text-cyan-300 text-sm rounded border border-cyan-400/30"
+              className="px-3 py-1 bg-crt-accent/20 text-crt-accent-hover text-sm rounded border border-crt-accent/30"
             >
               {tech}
             </span>

--- a/src/components/portfolio/DescriptionChannel.tsx
+++ b/src/components/portfolio/DescriptionChannel.tsx
@@ -5,6 +5,10 @@ interface DescriptionChannelProps {
   project: Project;
 }
 
+/**
+ * DescriptionChannel - Project description tab with Problem/Solution/Impact cards.
+ * Uses theme tokens for card backgrounds, borders, semantic colors, and text.
+ */
 export default function DescriptionChannel({ project }: DescriptionChannelProps) {
   return (
     <motion.div
@@ -16,37 +20,37 @@ export default function DescriptionChannel({ project }: DescriptionChannelProps)
     >
       <div className="max-w-4xl mx-auto">
         <div className="text-center mb-8">
-          <h2 className="text-3xl font-bold text-cyan-400 mb-2">{project.title}</h2>
-          <p className="text-gray-400 text-lg">{project.category}</p>
+          <h2 className="text-3xl font-bold text-crt-accent mb-2">{project.title}</h2>
+          <p className="text-crt-text-tertiary text-lg">{project.category}</p>
         </div>
         
         <div className="space-y-8">
           {/* Problem/Solution/Impact */}
           <div className="grid md:grid-cols-3 gap-6">
-            <div className="bg-gray-900/50 p-6 rounded-lg border border-gray-700">
-              <h3 className="text-xl font-bold text-red-400 mb-3">Problem</h3>
-              <p className="text-gray-300">{project.detailedDescription.problem}</p>
+            <div className="bg-crt-surface-primary/50 p-6 rounded-lg border border-crt-border">
+              <h3 className="text-xl font-bold text-crt-danger mb-3">Problem</h3>
+              <p className="text-crt-text-secondary">{project.detailedDescription.problem}</p>
             </div>
             
-            <div className="bg-gray-900/50 p-6 rounded-lg border border-gray-700">
-              <h3 className="text-xl font-bold text-yellow-400 mb-3">Solution</h3>
-              <p className="text-gray-300">{project.detailedDescription.solution}</p>
+            <div className="bg-crt-surface-primary/50 p-6 rounded-lg border border-crt-border">
+              <h3 className="text-xl font-bold text-crt-warning mb-3">Solution</h3>
+              <p className="text-crt-text-secondary">{project.detailedDescription.solution}</p>
             </div>
             
-            <div className="bg-gray-900/50 p-6 rounded-lg border border-gray-700">
-              <h3 className="text-xl font-bold text-green-400 mb-3">Impact</h3>
-              <p className="text-gray-300">{project.detailedDescription.impact}</p>
+            <div className="bg-crt-surface-primary/50 p-6 rounded-lg border border-crt-border">
+              <h3 className="text-xl font-bold text-crt-success mb-3">Impact</h3>
+              <p className="text-crt-text-secondary">{project.detailedDescription.impact}</p>
             </div>
           </div>
           
           {/* Key Highlights */}
-          <div className="bg-gray-900/30 p-6 rounded-lg border border-gray-700">
-            <h3 className="text-xl font-bold text-cyan-400 mb-4">Key Highlights</h3>
+          <div className="bg-crt-surface-primary/30 p-6 rounded-lg border border-crt-border">
+            <h3 className="text-xl font-bold text-crt-accent mb-4">Key Highlights</h3>
             <ul className="space-y-2">
               {project.detailedDescription.highlights.map((highlight, index) => (
                 <li key={index} className="flex items-start">
-                  <span className="text-cyan-400 mr-3 mt-1">•</span>
-                  <span className="text-gray-300">{highlight}</span>
+                  <span className="text-crt-accent mr-3 mt-1">•</span>
+                  <span className="text-crt-text-secondary">{highlight}</span>
                 </li>
               ))}
             </ul>
@@ -54,12 +58,12 @@ export default function DescriptionChannel({ project }: DescriptionChannelProps)
           
           {/* Tech Stack */}
           <div className="text-center">
-            <h3 className="text-xl font-bold text-cyan-400 mb-4">Technologies Used</h3>
+            <h3 className="text-xl font-bold text-crt-accent mb-4">Technologies Used</h3>
             <div className="flex flex-wrap justify-center gap-2">
               {project.tech.map((tech) => (
                 <span
                   key={tech}
-                  className="px-4 py-2 bg-cyan-400/20 text-cyan-300 rounded-lg border border-cyan-400/30"
+                  className="px-4 py-2 bg-crt-accent/20 text-crt-accent-hover rounded-lg border border-crt-accent/30"
                 >
                   {tech}
                 </span>

--- a/src/components/portfolio/ProjectDetailView.tsx
+++ b/src/components/portfolio/ProjectDetailView.tsx
@@ -15,6 +15,10 @@ interface ProjectDetailViewProps {
   onClose?: () => void;
 }
 
+/**
+ * ProjectDetailView - Expanded project view as a full-screen CRT modal.
+ * Uses theme tokens for backdrop, bezel, screen, and accent colors.
+ */
 export default function ProjectDetailView({ 
   project, 
   currentChannel, 
@@ -47,11 +51,11 @@ export default function ProjectDetailView({
   }, [onClose]);
 
   return (
-    <div className="fixed inset-0 z-50 bg-black/50 backdrop-blur-sm">
+    <div className="fixed inset-0 z-50 bg-crt-base/50 backdrop-blur-sm">
       {/* Animated TV Card - iOS App Store style */}
       <motion.div
         layoutId={`project-${project.id}`}
-        className="absolute inset-4 bg-gray-800 rounded-lg p-4 border-2 border-cyan-400/50 shadow-lg shadow-cyan-400/20 overflow-hidden"
+        className="absolute inset-4 bg-crt-surface-secondary rounded-lg p-4 border-2 border-crt-accent/50 shadow-lg shadow-crt-accent/20 overflow-hidden"
         transition={{ 
           type: "spring", 
           damping: 20, 
@@ -59,7 +63,7 @@ export default function ProjectDetailView({
         }}
       >
         {/* TV Screen Area */}
-        <div className="relative bg-black rounded border border-gray-600 overflow-hidden h-full">
+        <div className="relative bg-crt-shell-screen rounded border border-crt-border-secondary overflow-hidden h-full">
           
           {/* Channel Controls */}
           <motion.div 
@@ -89,7 +93,7 @@ export default function ProjectDetailView({
               onClick={onClose}
               variant="ghost"
               size="sm"
-              className="text-gray-400 hover:text-white"
+              className="text-crt-text-tertiary hover:text-crt-text"
             >
               ✕
             </CRTButton>
@@ -130,7 +134,7 @@ export default function ProjectDetailView({
           {/* CRT Effects */}
           <div className="absolute inset-0 pointer-events-none">
             <CRTScanlines opacity={0.1} lineHeight={2} lineSpacing={1} />
-            <div className="absolute inset-0 bg-gradient-to-br from-transparent via-transparent to-gray-900/5"></div>
+            <div className="absolute inset-0 bg-gradient-to-br from-transparent via-transparent to-crt-surface-primary/5"></div>
           </div>
         </div>
       </motion.div>

--- a/src/components/portfolio/ProjectTV.tsx
+++ b/src/components/portfolio/ProjectTV.tsx
@@ -9,6 +9,10 @@ interface ProjectTVProps {
   isSelected?: boolean;
 }
 
+/**
+ * ProjectTV - Individual project card styled as a mini CRT TV.
+ * Uses theme tokens for bezel, screen, and accent colors.
+ */
 export default function ProjectTV({ project, onClick, isSelected }: ProjectTVProps) {
   // Don't render the card if it's selected (it's now in the detail view)
   if (isSelected) return null;
@@ -22,10 +26,10 @@ export default function ProjectTV({ project, onClick, isSelected }: ProjectTVPro
       layoutId={`project-${project.id}`}
     >
       {/* CRT TV Bezel */}
-      <div className="bg-gray-800 rounded-lg p-4 border-2 border-gray-700 hover:border-cyan-400/50 transition-all duration-300 group-hover:shadow-lg group-hover:shadow-cyan-400/20">
+      <div className="bg-crt-surface-secondary rounded-lg p-4 border-2 border-crt-border hover:border-crt-accent/50 transition-all duration-300 group-hover:shadow-lg group-hover:shadow-crt-accent/20">
         
         {/* TV Screen */}
-        <div className="relative bg-black rounded border border-gray-600 overflow-hidden aspect-[4/3]">
+        <div className="relative bg-crt-shell-screen rounded border border-crt-border-secondary overflow-hidden aspect-[4/3]">
           
           {/* Screen Content */}
           <div className="absolute inset-0 p-4 flex flex-col justify-between">
@@ -33,9 +37,9 @@ export default function ProjectTV({ project, onClick, isSelected }: ProjectTVPro
             {/* Project Preview "Channel" */}
             <div className="space-y-2">
               <div className="flex items-center justify-between">
-                <span className="text-cyan-400 text-sm font-mono">{project.category}</span>
+                <span className="text-crt-accent text-sm font-mono">{project.category}</span>
                 <div 
-                  className="w-2 h-2 bg-red-500 rounded-full animate-pulse"
+                  className="w-2 h-2 bg-crt-danger rounded-full animate-pulse"
                   style={{
                     animationDelay: `${(project.id.charCodeAt(0) % 5) * 0.5}s`,
                     animationDuration: `${1.5 + (project.id.charCodeAt(1) % 3) * 0.5}s`
@@ -43,11 +47,11 @@ export default function ProjectTV({ project, onClick, isSelected }: ProjectTVPro
                 ></div>
               </div>
               
-              <h3 className="text-xl font-bold text-white group-hover:text-cyan-300 transition-colors">
+              <h3 className="text-xl font-bold text-crt-text group-hover:text-crt-accent-hover transition-colors">
                 {project.title}
               </h3>
               
-              <p className="text-gray-300 text-sm leading-relaxed">
+              <p className="text-crt-text-secondary text-sm leading-relaxed">
                 {project.description}
               </p>
             </div>
@@ -57,7 +61,7 @@ export default function ProjectTV({ project, onClick, isSelected }: ProjectTVPro
               {project.tech.slice(0, 3).map((tech) => (
                 <span 
                   key={tech} 
-                  className="px-2 py-1 bg-gray-900/80 text-xs rounded border border-gray-600 text-gray-300"
+                  className="px-2 py-1 bg-crt-surface-primary/80 text-xs rounded border border-crt-border-secondary text-crt-text-secondary"
                 >
                   {tech}
                 </span>
@@ -70,7 +74,7 @@ export default function ProjectTV({ project, onClick, isSelected }: ProjectTVPro
             {/* Scanlines */}
             <CRTScanlines opacity={0.15} lineHeight={3} lineSpacing={1} />
             {/* Screen curve effect */}
-            <div className="absolute inset-0 bg-gradient-to-br from-transparent via-transparent to-gray-900/10"></div>
+            <div className="absolute inset-0 bg-gradient-to-br from-transparent via-transparent to-crt-surface-primary/10"></div>
           </div>
           
           {/* Hover Static Effect */}
@@ -92,7 +96,7 @@ export default function ProjectTV({ project, onClick, isSelected }: ProjectTVPro
           </div>
           
           {/* Channel Number */}
-          <span className="text-gray-500 text-xs font-mono">
+          <span className="text-crt-text-muted text-xs font-mono">
             CH {project.id.slice(-2).toUpperCase()}
           </span>
         </div>

--- a/src/pages/Contact.tsx
+++ b/src/pages/Contact.tsx
@@ -7,14 +7,14 @@ interface ContactProps {
 
 export default function Contact({ onNavigate }: ContactProps) {
   return (
-    <div className="w-full h-full overflow-y-auto bg-black text-white">
+    <div className="w-full h-full overflow-y-auto bg-crt-base text-crt-text">
       <div className="min-h-full px-6 py-8 space-y-8">
         {/* Header */}
         <section className="text-center space-y-4 pt-8">
-          <h1 className="text-4xl md:text-5xl font-bold bg-gradient-to-r from-cyan-400 to-purple-400 bg-clip-text text-transparent">
+          <h1 className="text-4xl md:text-5xl font-bold bg-gradient-to-r from-crt-gradient-from to-crt-gradient-to bg-clip-text text-transparent">
             Let's Connect
           </h1>
-          <p className="text-gray-400 max-w-xl mx-auto leading-relaxed">
+          <p className="text-crt-text-tertiary max-w-xl mx-auto leading-relaxed">
             Ready to collaborate, discuss opportunities, or just chat about technology? 
             I'd love to hear from you!
           </p>
@@ -22,7 +22,7 @@ export default function Contact({ onNavigate }: ContactProps) {
 
         {/* Contact Links */}
         <section className="space-y-6">
-          <h2 className="text-2xl font-semibold text-center text-cyan-400">Get In Touch</h2>
+          <h2 className="text-2xl font-semibold text-center text-crt-accent">Get In Touch</h2>
           
           <div className="max-w-md mx-auto space-y-4">
             {/* LinkedIn */}
@@ -30,23 +30,23 @@ export default function Contact({ onNavigate }: ContactProps) {
               href="https://linkedin.com/in/ericsen-semedo" 
               target="_blank" 
               rel="noopener noreferrer"
-              className="flex items-center space-x-4 p-4 bg-gray-900/30 rounded-lg border border-gray-700/30 hover:border-blue-400/50 hover:bg-gray-800/40 transition-all duration-300 group"
+              className="flex items-center space-x-4 p-4 bg-crt-surface-primary/30 rounded-lg border border-crt-border/30 hover:border-crt-info/50 hover:bg-crt-surface-secondary/40 transition-all duration-300 group"
             >
               <div className="flex-shrink-0">
-                <svg className="w-8 h-8 text-blue-400 group-hover:text-blue-300 transition-colors" fill="currentColor" viewBox="0 0 24 24">
+                <svg className="w-8 h-8 text-crt-info group-hover:text-crt-info-hover transition-colors" fill="currentColor" viewBox="0 0 24 24">
                   <path d="M20.447 20.452h-3.554v-5.569c0-1.328-.027-3.037-1.852-3.037-1.853 0-2.136 1.445-2.136 2.939v5.667H9.351V9h3.414v1.561h.046c.477-.9 1.637-1.85 3.37-1.85 3.601 0 4.267 2.37 4.267 5.455v6.286zM5.337 7.433c-1.144 0-2.063-.926-2.063-2.065 0-1.138.92-2.063 2.063-2.063 1.14 0 2.064.925 2.064 2.063 0 1.139-.925 2.065-2.064 2.065zm1.782 13.019H3.555V9h3.564v11.452zM22.225 0H1.771C.792 0 0 .774 0 1.729v20.542C0 23.227.792 24 1.771 24h20.451C23.2 24 24 23.227 24 22.271V1.729C24 .774 23.2 0 22.222 0h.003z"/>
                 </svg>
               </div>
               <div className="flex-1">
-                <h3 className="text-lg font-semibold text-white group-hover:text-blue-300 transition-colors">
+                <h3 className="text-lg font-semibold text-crt-text group-hover:text-crt-info-hover transition-colors">
                   LinkedIn
                 </h3>
-                <p className="text-gray-400 text-sm">
+                <p className="text-crt-text-tertiary text-sm">
                   Professional network & experience
                 </p>
               </div>
               <div className="flex-shrink-0">
-                <svg className="w-5 h-5 text-gray-400 group-hover:text-blue-300 transition-colors" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <svg className="w-5 h-5 text-crt-text-tertiary group-hover:text-crt-info-hover transition-colors" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                   <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M10 6H6a2 2 0 00-2 2v10a2 2 0 002 2h10a2 2 0 002-2v-4M14 4h6m0 0v6m0-6L10 14" />
                 </svg>
               </div>
@@ -57,23 +57,23 @@ export default function Contact({ onNavigate }: ContactProps) {
               href="https://github.com/EricsenSemedo" 
               target="_blank" 
               rel="noopener noreferrer"
-              className="flex items-center space-x-4 p-4 bg-gray-900/30 rounded-lg border border-gray-700/30 hover:border-purple-400/50 hover:bg-gray-800/40 transition-all duration-300 group"
+              className="flex items-center space-x-4 p-4 bg-crt-surface-primary/30 rounded-lg border border-crt-border/30 hover:border-crt-secondary/50 hover:bg-crt-surface-secondary/40 transition-all duration-300 group"
             >
               <div className="flex-shrink-0">
-                <svg className="w-8 h-8 text-purple-400 group-hover:text-purple-300 transition-colors" fill="currentColor" viewBox="0 0 24 24">
+                <svg className="w-8 h-8 text-crt-secondary group-hover:text-crt-secondary-hover transition-colors" fill="currentColor" viewBox="0 0 24 24">
                   <path d="M12 0c-6.626 0-12 5.373-12 12 0 5.302 3.438 9.8 8.207 11.387.599.111.793-.261.793-.577v-2.234c-3.338.726-4.033-1.416-4.033-1.416-.546-1.387-1.333-1.756-1.333-1.756-1.089-.745.083-.729.083-.729 1.205.084 1.839 1.237 1.839 1.237 1.07 1.834 2.807 1.304 3.492.997.107-.775.418-1.305.762-1.604-2.665-.305-5.467-1.334-5.467-5.931 0-1.311.469-2.381 1.236-3.221-.124-.303-.535-1.524.117-3.176 0 0 1.008-.322 3.301 1.23.957-.266 1.983-.399 3.003-.404 1.02.005 2.047.138 3.006.404 2.291-1.552 3.297-1.23 3.297-1.23.653 1.653.242 2.874.118 3.176.77.84 1.235 1.911 1.235 3.221 0 4.609-2.807 5.624-5.479 5.921.43.372.823 1.102.823 2.222v3.293c0 .319.192.694.801.576 4.765-1.589 8.199-6.086 8.199-11.386 0-6.627-5.373-12-12-12z"/>
                 </svg>
               </div>
               <div className="flex-1">
-                <h3 className="text-lg font-semibold text-white group-hover:text-purple-300 transition-colors">
+                <h3 className="text-lg font-semibold text-crt-text group-hover:text-crt-secondary-hover transition-colors">
                   GitHub
                 </h3>
-                <p className="text-gray-400 text-sm">
+                <p className="text-crt-text-tertiary text-sm">
                   Projects, code & contributions
                 </p>
               </div>
               <div className="flex-shrink-0">
-                <svg className="w-5 h-5 text-gray-400 group-hover:text-purple-300 transition-colors" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <svg className="w-5 h-5 text-crt-text-tertiary group-hover:text-crt-secondary-hover transition-colors" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                   <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M10 6H6a2 2 0 00-2 2v10a2 2 0 002 2h10a2 2 0 002-2v-4M14 4h6m0 0v6m0-6L10 14" />
                 </svg>
               </div>
@@ -83,16 +83,16 @@ export default function Contact({ onNavigate }: ContactProps) {
 
         {/* Professional Info */}
         <section className="space-y-4">
-          <h3 className="text-xl font-semibold text-center text-cyan-400">Professional Focus</h3>
-          <div className="max-w-md mx-auto bg-gray-900/30 rounded-lg p-6 border border-gray-700/30">
+          <h3 className="text-xl font-semibold text-center text-crt-accent">Professional Focus</h3>
+          <div className="max-w-md mx-auto bg-crt-surface-primary/30 rounded-lg p-6 border border-crt-border/30">
             <div className="text-center space-y-3">
-              <div className="text-gray-300">
+              <div className="text-crt-text-secondary">
                 <strong>Currently Open To:</strong>
-                <div className="text-gray-400 mt-1">Full-time opportunities, freelance projects, collaboration</div>
+                <div className="text-crt-text-tertiary mt-1">Full-time opportunities, freelance projects, collaboration</div>
               </div>
-              <div className="text-gray-300">
+              <div className="text-crt-text-secondary">
                 <strong>Preferred Contact:</strong>
-                <div className="text-gray-400 mt-1">LinkedIn for professional inquiries</div>
+                <div className="text-crt-text-tertiary mt-1">LinkedIn for professional inquiries</div>
               </div>
             </div>
           </div>
@@ -100,8 +100,8 @@ export default function Contact({ onNavigate }: ContactProps) {
 
         {/* Call to Action */}
         <section className="text-center space-y-4 pb-8">
-          <h3 className="text-xl font-semibold text-gray-200">Ready to Start Something Great?</h3>
-          <p className="text-gray-400 max-w-lg mx-auto">
+          <h3 className="text-xl font-semibold text-crt-text-secondary">Ready to Start Something Great?</h3>
+          <p className="text-crt-text-tertiary max-w-lg mx-auto">
             Whether you have a project in mind, want to discuss opportunities, 
             or just want to connect with a fellow developer, I'm always excited to meet new people.
           </p>
@@ -112,8 +112,8 @@ export default function Contact({ onNavigate }: ContactProps) {
             >
               Back to Home
             </CRTButton>
-            <div className="px-3 py-2 bg-gradient-to-r from-cyan-600 to-purple-600 rounded-lg font-medium text-xs sm:text-base text-white flex items-center">
-              Let's build something amazing! 🚀
+            <div className="px-3 py-2 bg-gradient-to-r from-crt-accent-muted to-crt-secondary rounded-lg font-medium text-xs sm:text-base text-crt-text flex items-center">
+              Let's build something amazing!
             </div>
           </div>
         </section>

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -8,19 +8,19 @@ interface HomeProps {
 
 export default function Home({ onNavigate }: HomeProps) {
   return (
-    <div className="w-full h-full overflow-y-auto bg-black text-white">
+    <div className="w-full h-full overflow-y-auto bg-crt-base text-crt-text">
       <div className="min-h-full px-6 py-8 space-y-8">
         {/* Hero Section */}
         <section className="text-center space-y-4 pt-8">
           <div className="space-y-2">
-            <h1 className="text-4xl md:text-6xl font-bold bg-gradient-to-r from-cyan-400 to-purple-400 bg-clip-text text-transparent">
+            <h1 className="text-4xl md:text-6xl font-bold bg-gradient-to-r from-crt-gradient-from to-crt-gradient-to bg-clip-text text-transparent">
               Ericsen Semedo
             </h1>
-            <h2 className="text-xl md:text-2xl text-gray-300 font-light">
+            <h2 className="text-xl md:text-2xl text-crt-text-secondary font-light">
               Computer Science Graduate | Software Developer
             </h2>
           </div>
-          <p className="text-gray-400 max-w-2xl mx-auto leading-relaxed">
+          <p className="text-crt-text-tertiary max-w-2xl mx-auto leading-relaxed">
             Building innovative experiences in software and gaming. 
             Recent CS graduate from University of Rhode Island passionate about creating 
             cutting-edge solutions and immersive digital experiences.
@@ -29,15 +29,15 @@ export default function Home({ onNavigate }: HomeProps) {
 
         {/* Skills Section */}
         <section className="space-y-6">
-          <h3 className="text-2xl font-semibold text-center text-cyan-400">Skills & Technologies</h3>
+          <h3 className="text-2xl font-semibold text-center text-crt-accent">Skills & Technologies</h3>
           <div className="grid grid-cols-2 md:grid-cols-3 gap-4">
             {[
               'Python', 'Lua', 'C/C++', 
               'Java', 'AWS', 'OpenTofu',
               'Docker', 'Git', 'Roblox Studio'
             ].map((skill) => (
-              <div key={skill} className="bg-gray-900/50 rounded-lg p-3 text-center border border-gray-700/50 hover:border-cyan-400/30 transition-colors">
-                <span className="text-sm font-medium text-gray-300">{skill}</span>
+              <div key={skill} className="bg-crt-surface-primary/50 rounded-lg p-3 text-center border border-crt-border/50 hover:border-crt-accent/30 transition-colors">
+                <span className="text-sm font-medium text-crt-text-secondary">{skill}</span>
               </div>
             ))}
           </div>
@@ -45,20 +45,20 @@ export default function Home({ onNavigate }: HomeProps) {
 
         {/* Experience Section */}
         <section className="space-y-4">
-          <h3 className="text-2xl font-semibold text-center text-cyan-400">Experience</h3>
+          <h3 className="text-2xl font-semibold text-center text-crt-accent">Experience</h3>
           <div className="space-y-4">
-            <div className="bg-gray-900/30 rounded-lg p-6 border border-gray-700/30">
-              <h4 className="text-lg font-semibold text-cyan-300 mb-2">Infrastructure Engineer - PixelMux</h4>
-              <p className="text-gray-400 text-sm mb-3">Jan 2025 - Present | Remote</p>
-              <p className="text-gray-300 leading-relaxed">
+            <div className="bg-crt-surface-primary/30 rounded-lg p-6 border border-crt-border/30">
+              <h4 className="text-lg font-semibold text-crt-accent-hover mb-2">Infrastructure Engineer - PixelMux</h4>
+              <p className="text-crt-text-tertiary text-sm mb-3">Jan 2025 - Present | Remote</p>
+              <p className="text-crt-text-secondary leading-relaxed">
                 Designing IAM role architecture across multiple AWS accounts with granular permission boundaries. 
                 Developing RBAC strategies and implementing integration testing frameworks for core infrastructure modules.
               </p>
             </div>
-            <div className="bg-gray-900/30 rounded-lg p-6 border border-gray-700/30">
-              <h4 className="text-lg font-semibold text-cyan-300 mb-2">Freelance Programmer - Fiverr</h4>
-              <p className="text-gray-400 text-sm mb-3">Dec 2023 - Jan 2024 | Remote</p>
-              <p className="text-gray-300 leading-relaxed">
+            <div className="bg-crt-surface-primary/30 rounded-lg p-6 border border-crt-border/30">
+              <h4 className="text-lg font-semibold text-crt-accent-hover mb-2">Freelance Programmer - Fiverr</h4>
+              <p className="text-crt-text-tertiary text-sm mb-3">Dec 2023 - Jan 2024 | Remote</p>
+              <p className="text-crt-text-secondary leading-relaxed">
                 Delivered Lua programming for 4 Roblox games with top reviews. Refactored NPC/AI logic 
                 using Simple Path library and optimized game functionality through efficient scripting.
               </p>
@@ -68,28 +68,28 @@ export default function Home({ onNavigate }: HomeProps) {
 
         {/* Education & Stats */}
         <section className="space-y-4">
-          <div className="bg-gray-900/30 rounded-lg p-6 border border-gray-700/30 text-center">
-            <h4 className="text-lg font-semibold text-purple-400 mb-2">Education</h4>
-            <p className="text-gray-300">University of Rhode Island</p>
-            <p className="text-gray-400 text-sm">Bachelor of Arts in Computer Science</p>
-            <p className="text-gray-400 text-sm">Graduated: May 2025</p>
+          <div className="bg-crt-surface-primary/30 rounded-lg p-6 border border-crt-border/30 text-center">
+            <h4 className="text-lg font-semibold text-crt-secondary mb-2">Education</h4>
+            <p className="text-crt-text-secondary">University of Rhode Island</p>
+            <p className="text-crt-text-tertiary text-sm">Bachelor of Arts in Computer Science</p>
+            <p className="text-crt-text-tertiary text-sm">Graduated: May 2025</p>
           </div>
           <div className="grid grid-cols-2 gap-4">
-            <div className="text-center p-4 bg-gray-900/30 rounded-lg border border-gray-700/30">
-              <div className="text-2xl font-bold text-cyan-400">1+</div>
-              <div className="text-sm text-gray-400">Years Professional</div>
+            <div className="text-center p-4 bg-crt-surface-primary/30 rounded-lg border border-crt-border/30">
+              <div className="text-2xl font-bold text-crt-accent">1+</div>
+              <div className="text-sm text-crt-text-tertiary">Years Professional</div>
             </div>
-            <div className="text-center p-4 bg-gray-900/30 rounded-lg border border-gray-700/30">
-              <div className="text-2xl font-bold text-purple-400">{projects.length}+</div>
-              <div className="text-sm text-gray-400">Projects Built</div>
+            <div className="text-center p-4 bg-crt-surface-primary/30 rounded-lg border border-crt-border/30">
+              <div className="text-2xl font-bold text-crt-secondary">{projects.length}+</div>
+              <div className="text-sm text-crt-text-tertiary">Projects Built</div>
             </div>
           </div>
         </section>
 
         {/* Call to Action */}
         <section className="text-center space-y-4 pb-8">
-          <h3 className="text-xl font-semibold text-gray-200">Let's Build Something Amazing</h3>
-          <p className="text-gray-400">
+          <h3 className="text-xl font-semibold text-crt-text-secondary">Let's Build Something Amazing</h3>
+          <p className="text-crt-text-tertiary">
             Ready to bring your ideas to life? Let's connect and discuss your next project.
           </p>
           <div className="flex justify-center space-x-4">

--- a/src/pages/Portfolio.tsx
+++ b/src/pages/Portfolio.tsx
@@ -16,13 +16,13 @@ export default function Portfolio({ onNavigate }: PortfolioProps) {
   const [currentChannel, setCurrentChannel] = useState<ChannelType>('demo');
 
   return (
-    <div className="w-full h-full overflow-y-auto text-white bg-black">
+    <div className="w-full h-full overflow-y-auto text-crt-text bg-crt-base">
       {/* Header */}
       <section className="text-center space-y-4 pt-8 px-6">
-        <h1 className="text-4xl md:text-5xl font-bold bg-gradient-to-r from-cyan-400 to-purple-400 bg-clip-text text-transparent leading-tight pb-2">
+        <h1 className="text-4xl md:text-5xl font-bold bg-gradient-to-r from-crt-gradient-from to-crt-gradient-to bg-clip-text text-transparent leading-tight pb-2">
           Project Gallery
         </h1>
-        <p className="text-gray-400 max-w-2xl mx-auto">
+        <p className="text-crt-text-tertiary max-w-2xl mx-auto">
           Browse through my project channels. Click any TV to tune in and explore the details.
         </p>
       </section>


### PR DESCRIPTION
## Summary
Completes the theme migration by converting all 3 page components to theme tokens and adding an interactive dark/light mode toggle button.

**Stacks on**: #23 (component migration) -> #22 (theme foundation)

## Changes

### Page Migrations
| Page | Notable Changes |
|------|----------------|
| `Home.tsx` | Hero gradient -> `from-crt-gradient-from to-crt-gradient-to`, all cards/text/borders use `crt-surface-primary`, `crt-text-*`, `crt-border` tokens |
| `Portfolio.tsx` | Background, text, and gradient heading tokenized |
| `Contact.tsx` | LinkedIn uses `crt-info/crt-info-hover`, GitHub uses `crt-secondary/crt-secondary-hover`, CTA gradient tokenized, emoji removed per style guide |

### New Component
| File | Purpose |
|------|---------|
| `ThemeToggle.tsx` | Floating CRT-styled toggle button (bottom-right corner). Features: sun/moon icon swap with rotation+scale animation, CRT scanline overlay on hover, accent-colored strokes, `useTheme` hook integration |

### App Integration
- `App.tsx`: Import + render `<ThemeToggle />` at root level (fixed position, z-50)

## After This PR
The entire CRT Portfolio is fully theme-switchable:
- Click the toggle in the bottom-right corner to switch between dark and light mode
- Preference persists in localStorage
- First visit respects OS `prefers-color-scheme`
- All components, effects, and pages respond to the theme change via CSS custom properties

## What's Next
- **PR 4**: Typography + color palette refinement (distinctive fonts, palette tuning for CRT authenticity)

## Verification
- Build: passing (362KB JS, 39KB CSS)
- Lint: clean (0 errors, 0 warnings)