### PR TITLE
feat: theme-aware CRT effect intensity scaling

### DIFF
--- a/src/components/CRTButton.tsx
+++ b/src/components/CRTButton.tsx
@@ -91,11 +91,12 @@ export default function CRTButton({
       onMouseUp={handleMouseUp}
       {...props}
     >
-      {/* CRT scanline overlay effect */}
+      {/* CRT scanline overlay effect - scales with theme scanline intensity */}
       <div className="absolute inset-0 opacity-0 group-hover:opacity-20 transition-opacity duration-200 pointer-events-none">
         <div 
           className="w-full h-full"
           style={{
+            opacity: "var(--crt-scanline-opacity)",
             background: `repeating-linear-gradient(
               0deg,
               transparent 0px,

--- a/src/components/CRTScanlines.tsx
+++ b/src/components/CRTScanlines.tsx
@@ -8,6 +8,7 @@ interface CRTScanlinesProps {
 /**
  * CRTScanlines - Horizontal scanlines effect that mimics CRT display technology.
  * Uses --crt-scanline-color token so lines adapt to dark/light theme.
+ * Opacity scales with --crt-scanline-opacity for theme-aware intensity.
  */
 export default function CRTScanlines({ 
   opacity = 0.2, 
@@ -19,7 +20,7 @@ export default function CRTScanlines({
     <div 
       className={`absolute inset-0 pointer-events-none ${className}`}
       style={{
-        opacity,
+        opacity: `calc(${opacity} * var(--crt-scanline-opacity))`,
         background: `repeating-linear-gradient(
           0deg,
           transparent 0px,

--- a/src/components/CRTVignette.tsx
+++ b/src/components/CRTVignette.tsx
@@ -7,6 +7,7 @@ interface CRTVignetteProps {
 /**
  * CRTVignette - Subtle vignette effect that mimics CRT monitor darkening at edges.
  * Uses --crt-vignette-color token (always dark, even in light mode).
+ * Scales with --crt-vignette-opacity for theme-aware intensity.
  */
 export default function CRTVignette({ 
   intensity = 0.3, 
@@ -17,6 +18,7 @@ export default function CRTVignette({
     <div 
       className={`absolute inset-0 pointer-events-none ${className}`}
       style={{
+        opacity: `var(--crt-vignette-opacity)`,
         background: `radial-gradient(circle at center, transparent ${innerRadius}%, rgb(var(--crt-vignette-color) / ${intensity}) 100%)`
       }}
     />

--- a/src/components/StaticNoise.tsx
+++ b/src/components/StaticNoise.tsx
@@ -6,10 +6,14 @@ interface StaticNoiseProps {
 /**
  * StaticNoise - Animated TV static with fizz and noise layers.
  * Uses --crt-noise-light/dark tokens so noise adapts to theme.
+ * Scales with --crt-noise-opacity for theme-aware intensity.
  */
 export default function StaticNoise({ intensity = 1, className = "" }: StaticNoiseProps) {
   return (
-    <div className={`absolute inset-0 pointer-events-none ${className}`}>
+    <div
+      className={`absolute inset-0 pointer-events-none ${className}`}
+      style={{ opacity: `var(--crt-noise-opacity)` }}
+    >
       {/* CRT static fizz effect */}
       <div
         className="absolute inset-0 mix-blend-screen animate-[fizz_0.5s_steps(6)_infinite]"

--- a/src/components/TVShell.tsx
+++ b/src/components/TVShell.tsx
@@ -51,7 +51,7 @@ export default function TVShell({
                 style={{
                   background: "radial-gradient(120% 100% at 50% 50%, rgb(var(--crt-glow-color) / 0.18), rgb(var(--crt-glow-color) / 0) 60%)",
                   mixBlendMode: "screen",
-                  opacity: 0.6,
+                  opacity: `calc(0.6 * var(--crt-glow-opacity))`,
                 }}
               />
 
@@ -61,7 +61,7 @@ export default function TVShell({
                 style={{
                   background: "radial-gradient(120% 100% at 50% 50%, rgb(var(--crt-glow-color) / 0.66), rgb(var(--crt-vignette-color) / 0.15) 60%, rgb(var(--crt-vignette-color) / 0.65) 100%)",
                   mixBlendMode: "overlay",
-                  opacity: .9 * intensity,
+                  opacity: `calc(${.9 * intensity} * var(--crt-vignette-opacity))`,
                 }}
               />
 
@@ -70,14 +70,17 @@ export default function TVShell({
                 className="pointer-events-none absolute inset-0"
                 style={{
                   background: "repeating-linear-gradient(180deg, rgb(var(--crt-scanline-color) / 0.04) 0px, rgb(var(--crt-scanline-color) / 0.04) 1px, transparent 2px, transparent 3px)",
-                  opacity: .2 * intensity,
+                  opacity: `calc(${.2 * intensity} * var(--crt-scanline-opacity))`,
                 }}
               />
 
               {/* Bloom line */}
               <div
                 className="pointer-events-none absolute inset-x-0 top-12 h-[2px] blur-[2px]"
-                style={{ backgroundColor: "rgb(var(--crt-glow-color) / 0.1)" }}
+                style={{
+                  backgroundColor: "rgb(var(--crt-glow-color) / 0.1)",
+                  opacity: `var(--crt-bloom-opacity)`,
+                }}
               />
 
             </div>

--- a/src/components/TVZoomOverlay.tsx
+++ b/src/components/TVZoomOverlay.tsx
@@ -129,24 +129,26 @@ export default function TVZoomOverlay({ selectedItem, onClose, children }: TVZoo
                       </div>
                     )}
                     
-                    {/* CRT sweep line */}
+                    {/* CRT sweep line - scales with theme glow intensity */}
                     {sweepVisible && (
                       <div
                         className="pointer-events-none absolute inset-x-0 h-8 -top-8"
                         style={{
                           background: "linear-gradient(to bottom, rgb(var(--crt-glow-color) / 0.15), rgb(var(--crt-glow-color) / 0.05), transparent)",
                           boxShadow: "0 0 20px rgb(var(--crt-glow-color) / 0.3)",
+                          opacity: "var(--crt-glow-opacity)",
                           mixBlendMode: "screen",
                           animation: "sweepLine 0.4s linear forwards",
                         }}
                       />
                     )}
                     
-                    {/* Static noise overlay in unswept area */}
+                    {/* Static noise overlay in unswept area - scales with theme noise intensity */}
                     {sweepVisible && (
                       <div
-                        className="pointer-events-none absolute inset-0 opacity-40"
+                        className="pointer-events-none absolute inset-0"
                         style={{
+                          opacity: "calc(0.4 * var(--crt-noise-opacity))",
                           background: `
                             repeating-linear-gradient(
                               0deg,

--- a/src/index.css
+++ b/src/index.css
@@ -135,6 +135,13 @@
   --crt-noise-light: 255 255 255;    /* noise bright */
   --crt-noise-dark: 0 0 0;           /* noise dark */
 
+  /* CRT Effect Intensities (multipliers for dark room) */
+  --crt-scanline-opacity: 1;
+  --crt-vignette-opacity: 1;
+  --crt-noise-opacity: 1;
+  --crt-glow-opacity: 1;
+  --crt-bloom-opacity: 1;
+
   /* Gradient endpoints */
   --crt-gradient-from: 34 211 238;   /* cyan-400 */
   --crt-gradient-to: 192 132 252;    /* purple-400 */
@@ -199,6 +206,13 @@
   --crt-vignette-color: 0 0 0;       /* still dark vignette */
   --crt-noise-light: 0 0 0;          /* inverted noise */
   --crt-noise-dark: 255 255 255;     /* inverted noise */
+
+  /* CRT Effect Intensities (subdued for bright room) */
+  --crt-scanline-opacity: 0.5;
+  --crt-vignette-opacity: 0.6;
+  --crt-noise-opacity: 0.4;
+  --crt-glow-opacity: 0.3;
+  --crt-bloom-opacity: 0.4;
 
   /* Gradient endpoints */
   --crt-gradient-from: 8 145 178;    /* cyan-600 */


### PR DESCRIPTION
## Summary

- Add CSS custom properties for CRT effect intensities (`--crt-scanline-opacity`, `--crt-vignette-opacity`, `--crt-noise-opacity`, `--crt-glow-opacity`, `--crt-bloom-opacity`) with distinct values for dark and light modes
- Scale all CRT effect components (CRTScanlines, CRTVignette, StaticNoise, TVShell, TVZoomOverlay, CRTButton) using `calc()` multiplication with these intensity tokens
- Dark mode retains full-intensity effects; light mode reduces them (0.3-0.6x) for better readability

## Changes

| File | Change |
|------|--------|
| `src/index.css` | Added 5 intensity tokens to `:root` (dark) and `.light` blocks |
| `src/components/CRTScanlines.tsx` | Opacity scales with `--crt-scanline-opacity` |
| `src/components/CRTVignette.tsx` | Wrapper div opacity uses `--crt-vignette-opacity` |
| `src/components/StaticNoise.tsx` | Container opacity uses `--crt-noise-opacity` |
| `src/components/TVShell.tsx` | Glass curvature, vignette, scanlines, and bloom scale with respective tokens |
| `src/components/TVZoomOverlay.tsx` | Sweep glow scales with `--crt-glow-opacity`, noise with `--crt-noise-opacity` |
| `src/components/CRTButton.tsx` | Scanline hover overlay inner div scales with `--crt-scanline-opacity` |

## Verification

- `yarn build` passes
- `yarn lint` passes
- `yarn vitest run` passes (14/14 tests)

## Stacked PR

This PR targets `feat/typography` (PR #25). Merge #25 first.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * CRT visual effects (scanlines, vignette, noise, and glow) now support customizable intensity with theme-aware defaults
  * Dark and light theme presets included for optimal appearance across different modes
  * Enhanced control over visual effect visibility at runtime

<!-- end of auto-generated comment: release notes by coderabbit.ai -->