### PR TITLE
fix: polish ThemeToggle with Framer Motion, focus ring, and accessibility

### DIFF
--- a/src/components/ThemeToggle.tsx
+++ b/src/components/ThemeToggle.tsx
@@ -1,4 +1,4 @@
-import { AnimatePresence, motion } from "framer-motion";
+import { AnimatePresence, motion, useReducedMotion } from "framer-motion";
 import { useTheme } from "../hooks/useTheme";
 
 /**
@@ -6,23 +6,38 @@ import { useTheme } from "../hooks/useTheme";
  * Rendered as a physical toggle knob that matches the TV aesthetic.
  * Uses Framer Motion spring animations for icon transitions and CRT-style
  * press effects consistent with CRTButton.
+ * Respects prefers-reduced-motion via useReducedMotion hook.
  */
 export default function ThemeToggle() {
   const { theme, toggleTheme } = useTheme();
   const isDark = theme === "dark";
+  const prefersReducedMotion = useReducedMotion();
+
+  const springTransition = prefersReducedMotion
+    ? { duration: 0 }
+    : { type: "spring" as const, damping: 15, stiffness: 400 };
+
+  const iconTransition = prefersReducedMotion
+    ? { duration: 0 }
+    : { type: "spring" as const, damping: 15, stiffness: 300 };
 
   return (
     <motion.button
+      type="button"
       onClick={toggleTheme}
       className="fixed bottom-4 right-4 z-50 group cursor-pointer focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-crt-accent/50 focus-visible:ring-offset-2 focus-visible:ring-offset-crt-base rounded-full"
       aria-label={`Switch to ${isDark ? "light" : "dark"} mode`}
       title={`Switch to ${isDark ? "light" : "dark"} mode`}
-      whileHover={{ scale: 1.05 }}
-      whileTap={{
-        scale: 0.95,
-        filter: "contrast(1.3) brightness(1.2) hue-rotate(5deg)",
-      }}
-      transition={{ type: "spring", damping: 15, stiffness: 400 }}
+      whileHover={prefersReducedMotion ? undefined : { scale: 1.05 }}
+      whileTap={
+        prefersReducedMotion
+          ? undefined
+          : {
+              scale: 0.95,
+              filter: "contrast(1.3) brightness(1.2) hue-rotate(5deg)",
+            }
+      }
+      transition={springTransition}
     >
       {/* Outer knob housing */}
       <div className="relative w-12 h-12 rounded-full bg-crt-surface-secondary border-2 border-crt-border shadow-lg transition-all duration-300 motion-reduce:transition-none group-hover:border-crt-accent/50 group-hover:shadow-crt-accent/20">
@@ -38,10 +53,10 @@ export default function ThemeToggle() {
                 strokeWidth="2"
                 viewBox="0 0 24 24"
                 aria-hidden="true"
-                initial={{ opacity: 0, rotate: -90, scale: 0 }}
+                initial={prefersReducedMotion ? false : { opacity: 0, rotate: -90, scale: 0 }}
                 animate={{ opacity: 1, rotate: 0, scale: 1 }}
-                exit={{ opacity: 0, rotate: 90, scale: 0 }}
-                transition={{ type: "spring", damping: 15, stiffness: 300 }}
+                exit={prefersReducedMotion ? { opacity: 0 } : { opacity: 0, rotate: 90, scale: 0 }}
+                transition={iconTransition}
               >
                 <path d="M21 12.79A9 9 0 1111.21 3 7 7 0 0021 12.79z" />
               </motion.svg>
@@ -54,10 +69,10 @@ export default function ThemeToggle() {
                 strokeWidth="2"
                 viewBox="0 0 24 24"
                 aria-hidden="true"
-                initial={{ opacity: 0, rotate: 90, scale: 0 }}
+                initial={prefersReducedMotion ? false : { opacity: 0, rotate: 90, scale: 0 }}
                 animate={{ opacity: 1, rotate: 0, scale: 1 }}
-                exit={{ opacity: 0, rotate: -90, scale: 0 }}
-                transition={{ type: "spring", damping: 15, stiffness: 300 }}
+                exit={prefersReducedMotion ? { opacity: 0 } : { opacity: 0, rotate: -90, scale: 0 }}
+                transition={iconTransition}
               >
                 <circle cx="12" cy="12" r="5" />
                 <path d="M12 1v2M12 21v2M4.22 4.22l1.42 1.42M18.36 18.36l1.42 1.42M1 12h2M21 12h2M4.22 19.78l1.42-1.42M18.36 5.64l1.42-1.42" />
@@ -76,7 +91,7 @@ export default function ThemeToggle() {
               transparent 2px,
               rgb(var(--crt-scanline-color) / 0.08) 2px,
               rgb(var(--crt-scanline-color) / 0.08) 3px
-            )`
+            )`,
           }}
         />
       </div>

--- a/src/components/ThemeToggle.tsx
+++ b/src/components/ThemeToggle.tsx
@@ -1,50 +1,74 @@
+import { AnimatePresence, motion } from "framer-motion";
 import { useTheme } from "../hooks/useTheme";
 
 /**
  * ThemeToggle - CRT-styled dark/light mode switch.
  * Rendered as a physical toggle knob that matches the TV aesthetic.
+ * Uses Framer Motion spring animations for icon transitions and CRT-style
+ * press effects consistent with CRTButton.
  */
 export default function ThemeToggle() {
   const { theme, toggleTheme } = useTheme();
   const isDark = theme === "dark";
 
   return (
-    <button
+    <motion.button
       onClick={toggleTheme}
-      className="fixed bottom-4 right-4 z-50 group cursor-pointer"
+      className="fixed bottom-4 right-4 z-50 group cursor-pointer focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-crt-accent/50 focus-visible:ring-offset-2 focus-visible:ring-offset-crt-base rounded-full"
       aria-label={`Switch to ${isDark ? "light" : "dark"} mode`}
       title={`Switch to ${isDark ? "light" : "dark"} mode`}
+      whileHover={{ scale: 1.05 }}
+      whileTap={{
+        scale: 0.95,
+        filter: "contrast(1.3) brightness(1.2) hue-rotate(5deg)",
+      }}
+      transition={{ type: "spring", damping: 15, stiffness: 400 }}
     >
       {/* Outer knob housing */}
-      <div className="relative w-12 h-12 rounded-full bg-crt-surface-secondary border-2 border-crt-border shadow-lg transition-all duration-300 group-hover:border-crt-accent/50 group-hover:shadow-crt-accent/20 group-active:scale-95">
+      <div className="relative w-12 h-12 rounded-full bg-crt-surface-secondary border-2 border-crt-border shadow-lg transition-all duration-300 motion-reduce:transition-none group-hover:border-crt-accent/50 group-hover:shadow-crt-accent/20">
         {/* Inner indicator */}
-        <div className="absolute inset-2 rounded-full flex items-center justify-center transition-all duration-300">
-          {/* Sun icon (light mode) */}
-          <svg
-            className={`w-5 h-5 absolute transition-all duration-300 ${isDark ? "opacity-0 rotate-90 scale-0" : "opacity-100 rotate-0 scale-100"}`}
-            fill="none"
-            stroke="rgb(var(--crt-accent-primary))"
-            strokeWidth="2"
-            viewBox="0 0 24 24"
-          >
-            <circle cx="12" cy="12" r="5" />
-            <path d="M12 1v2M12 21v2M4.22 4.22l1.42 1.42M18.36 18.36l1.42 1.42M1 12h2M21 12h2M4.22 19.78l1.42-1.42M18.36 5.64l1.42-1.42" />
-          </svg>
-          {/* Moon icon (dark mode) */}
-          <svg
-            className={`w-5 h-5 absolute transition-all duration-300 ${isDark ? "opacity-100 rotate-0 scale-100" : "opacity-0 -rotate-90 scale-0"}`}
-            fill="none"
-            stroke="rgb(var(--crt-accent-primary))"
-            strokeWidth="2"
-            viewBox="0 0 24 24"
-          >
-            <path d="M21 12.79A9 9 0 1111.21 3 7 7 0 0021 12.79z" />
-          </svg>
+        <div className="absolute inset-2 rounded-full flex items-center justify-center">
+          <AnimatePresence mode="wait" initial={false}>
+            {isDark ? (
+              <motion.svg
+                key="moon"
+                className="w-5 h-5 absolute"
+                fill="none"
+                stroke="rgb(var(--crt-accent-primary))"
+                strokeWidth="2"
+                viewBox="0 0 24 24"
+                aria-hidden="true"
+                initial={{ opacity: 0, rotate: -90, scale: 0 }}
+                animate={{ opacity: 1, rotate: 0, scale: 1 }}
+                exit={{ opacity: 0, rotate: 90, scale: 0 }}
+                transition={{ type: "spring", damping: 15, stiffness: 300 }}
+              >
+                <path d="M21 12.79A9 9 0 1111.21 3 7 7 0 0021 12.79z" />
+              </motion.svg>
+            ) : (
+              <motion.svg
+                key="sun"
+                className="w-5 h-5 absolute"
+                fill="none"
+                stroke="rgb(var(--crt-accent-primary))"
+                strokeWidth="2"
+                viewBox="0 0 24 24"
+                aria-hidden="true"
+                initial={{ opacity: 0, rotate: 90, scale: 0 }}
+                animate={{ opacity: 1, rotate: 0, scale: 1 }}
+                exit={{ opacity: 0, rotate: -90, scale: 0 }}
+                transition={{ type: "spring", damping: 15, stiffness: 300 }}
+              >
+                <circle cx="12" cy="12" r="5" />
+                <path d="M12 1v2M12 21v2M4.22 4.22l1.42 1.42M18.36 18.36l1.42 1.42M1 12h2M21 12h2M4.22 19.78l1.42-1.42M18.36 5.64l1.42-1.42" />
+              </motion.svg>
+            )}
+          </AnimatePresence>
         </div>
 
         {/* CRT scanline overlay on hover */}
         <div
-          className="absolute inset-0 rounded-full opacity-0 group-hover:opacity-30 transition-opacity duration-200 pointer-events-none overflow-hidden"
+          className="absolute inset-0 rounded-full opacity-0 group-hover:opacity-30 transition-opacity duration-200 motion-reduce:transition-none pointer-events-none overflow-hidden"
           style={{
             background: `repeating-linear-gradient(
               0deg,
@@ -56,6 +80,6 @@ export default function ThemeToggle() {
           }}
         />
       </div>
-    </button>
+    </motion.button>
   );
 }


### PR DESCRIPTION
## Summary

- Replace CSS transitions with Framer Motion spring animations for the icon swap
- Add visible focus ring for keyboard accessibility (WCAG 2.4.7)
- Add CRT-style glitch effect on press, consistent with CRTButton
- Add `aria-hidden` to decorative SVGs and `motion-reduce` support

## Changes (1 file, ~50 lines)

**`src/components/ThemeToggle.tsx`:**

| Before | After |
|--------|-------|
| `<button>` | `<motion.button>` with `whileHover`/`whileTap` |
| CSS `transition-all` for icon swap | `AnimatePresence mode="wait"` with `motion.svg` spring animations |
| No focus indicator | `focus-visible:ring-2 focus-visible:ring-crt-accent/50` |
| No CRT press effect | `whileTap` with `contrast(1.3) brightness(1.2) hue-rotate(5deg)` |
| SVGs without aria | `aria-hidden="true"` on both sun/moon icons |
| No reduced-motion | `motion-reduce:transition-none` on CSS transitions |

## Verification

- `yarn build` passes
- `yarn lint` passes
- `yarn vitest run` passes (14/14 tests)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Theme toggle now uses animated button with smooth spring-like hover and tap interactions
  * Sun and moon icons transition with enter/exit animations when switching themes
  * Hover/active visual effects apply only when motion is allowed, respecting reduced-motion preferences
  * Enhanced keyboard focus indicators for improved accessibility
  * Visual overlays and transitions adjusted for motion-reduction safety
<!-- end of auto-generated comment: release notes by coderabbit.ai -->