### PR TITLE
feat: responsive TV stage layout for all screen sizes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,15 +12,10 @@ If a tradeoff is required, choose correctness and robustness over short-term con
 
 Long-term maintainability is a core priority. Before adding functionality, check if there is shared logic that can be extracted to a separate module. Duplicate logic across files is a code smell. Don't take shortcuts by adding local logic — change existing code instead.
 
-## Package Manager
-
-**Bun only.** Use `bun` for installing dependencies and running scripts, `bunx` for one-off executables. Never use `npm`, `npx`, `yarn`, or `pnpm`.
-
 ## Commands
 
 | Command | Description |
 | --- | --- |
-| `bun install` | Install dependencies |
 | `bun run dev` | Vite dev server with HMR |
 | `bun run build` | Production build (also type-checks) |
 | `bun run lint` | ESLint |
@@ -41,7 +36,7 @@ Type-check without building: `bunx tsc --noEmit`
 
 ## PRs
 
-Keep PRs small (100–300 lines, max 500). Run `cr review --plain --base main` before submitting.
+Keep PRs small (50–150 lines). Run `cr review --plain --base main` before submitting.
 
 ## Cursor Cloud specific instructions
 

--- a/bun.lock
+++ b/bun.lock
@@ -6,14 +6,12 @@
       "name": "crt-portfolio",
       "dependencies": {
         "framer-motion": "^12.23.12",
-        "howler": "^2.2.4",
         "react": "^19.1.1",
         "react-dom": "^19.1.1",
       },
       "devDependencies": {
         "@eslint/js": "^9.33.0",
         "@tailwindcss/postcss": "^4.1.12",
-        "@types/howler": "^2.2.12",
         "@types/react": "^19.1.10",
         "@types/react-dom": "^19.1.7",
         "@vitejs/plugin-react": "^5.0.0",
@@ -291,8 +289,6 @@
 
     "@types/estree": ["@types/estree@1.0.8", "", {}, "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w=="],
 
-    "@types/howler": ["@types/howler@2.2.12", "", {}, "sha512-hy769UICzOSdK0Kn1FBk4gN+lswcj1EKRkmiDtMkUGvFfYJzgaDXmVXkSShS2m89ERAatGIPnTUlp2HhfkVo5g=="],
-
     "@types/json-schema": ["@types/json-schema@7.0.15", "", {}, "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA=="],
 
     "@types/react": ["@types/react@19.2.13", "", { "dependencies": { "csstype": "^3.2.2" } }, "sha512-KkiJeU6VbYbUOp5ITMIc7kBfqlYkKA5KhEHVrGMmUUMt7NeaZg65ojdPk+FtNrBAOXNVM5QM72jnADjM+XVRAQ=="],
@@ -464,8 +460,6 @@
     "graceful-fs": ["graceful-fs@4.2.11", "", {}, "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ=="],
 
     "has-flag": ["has-flag@4.0.0", "", {}, "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="],
-
-    "howler": ["howler@2.2.4", "", {}, "sha512-iARIBPgcQrwtEr+tALF+rapJ8qSc+Set2GJQl7xT1MQzWaVkFebdJhR3alVlSiUf5U7nAANKuj3aWpwerocD5w=="],
 
     "html-encoding-sniffer": ["html-encoding-sniffer@6.0.0", "", { "dependencies": { "@exodus/bytes": "^1.6.0" } }, "sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg=="],
 

--- a/package.json
+++ b/package.json
@@ -13,14 +13,12 @@
   },
   "dependencies": {
     "framer-motion": "^12.23.12",
-    "howler": "^2.2.4",
     "react": "^19.1.1",
     "react-dom": "^19.1.1"
   },
   "devDependencies": {
     "@eslint/js": "^9.33.0",
     "@tailwindcss/postcss": "^4.1.12",
-    "@types/howler": "^2.2.12",
     "@types/react": "^19.1.10",
     "@types/react-dom": "^19.1.7",
     "@vitejs/plugin-react": "^5.0.0",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -32,9 +32,9 @@ export default function App() {
   // ========================================
 
   const TVs: TVConfig[] = useMemo(() => ([
-    { id: 'home', title: 'HOME', width: 340 },
-    { id: 'portfolio', title: 'PORTFOLIO', width: 340 },
-    { id: 'contact', title: 'CONTACT', width: 340 },
+    { id: 'home', title: 'HOME', width: 340, variant: 'boxy-80s' },
+    { id: 'portfolio', title: 'PORTFOLIO', width: 340, variant: 'rounded-60s' },
+    { id: 'contact', title: 'CONTACT', width: 340, variant: 'monitor-90s' },
   ]), []);
 
   const panRef = useRef<PanStageRef>(null);
@@ -95,7 +95,7 @@ export default function App() {
                 data-pan-id={tv.id}
                 className="aspect-square w-[clamp(12rem,24vw,20rem)]"
               >
-                <TVShell className="w-full h-full cursor-pointer">
+                <TVShell className="w-full h-full cursor-pointer" variant={tv.variant}>
                   <div className="h-full flex items-center justify-center">
                     <StaticNoise intensity={1} />
                     <div className="text-crt-text font-display font-semibold text-center text-sm sm:text-base tracking-wider">

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -87,18 +87,18 @@ export default function App() {
           <PanStage
             ref={panRef}
             onStateChange={setPanState}
-            className="mx-auto min-h-screen flex items-center justify-center"
+            className="mx-auto max-w-[1600px] min-h-screen flex items-center justify-center px-4 sm:px-8"
           >
             {TVs.map(tv => (
               <div
                 key={tv.id}
                 data-pan-id={tv.id}
-                className="aspect-square w-[clamp(12rem,24vw,20rem)]"
+                className="aspect-square w-[clamp(14rem,70vw,18rem)] sm:w-[clamp(12rem,30vw,16rem)] md:w-[clamp(14rem,24vw,20rem)] lg:w-[clamp(16rem,20vw,22rem)]"
               >
                 <TVShell className="w-full h-full cursor-pointer" variant={tv.variant}>
                   <div className="h-full flex items-center justify-center">
                     <StaticNoise intensity={1} />
-                    <div className="text-crt-text font-display font-semibold text-center text-sm sm:text-base tracking-wider">
+                    <div className="text-crt-text font-display font-semibold text-center text-xs sm:text-sm md:text-base tracking-wider">
                       {tv.title}
                     </div>
                   </div>

--- a/src/components/PanStage.tsx
+++ b/src/components/PanStage.tsx
@@ -332,7 +332,7 @@ const PanStage = forwardRef<PanStageRef, PanStageProps>(function PanStage(
         ref={containerRef}
         animate={controls}
         transition={{ type: 'spring', duration: 0.5, bounce: 0.2 }}
-        className="origin-top-left flex flex-col md:flex-row items-center justify-center gap-6 md:gap-8"
+        className="origin-top-left flex flex-col sm:flex-row items-center justify-center gap-4 sm:gap-6 md:gap-8 lg:gap-10"
         style={{
           willChange: 'transform',
           transform: 'translate3d(0, 0, 0)',

--- a/src/components/TVShell.tsx
+++ b/src/components/TVShell.tsx
@@ -1,4 +1,6 @@
-import type { ReactNode } from 'react';
+import type { CSSProperties, ReactNode } from 'react';
+
+export type TVVariant = "boxy-80s" | "rounded-60s" | "monitor-90s";
 
 interface TVShellProps {
   children?: ReactNode;
@@ -6,39 +8,78 @@ interface TVShellProps {
   brightness?: number;
   intensity?: number;
   frameClassName?: string;
+  variant?: TVVariant;
+  shellStyle?: CSSProperties;
 }
 
+const VARIANT_CONFIG = {
+  "boxy-80s": {
+    bodyRadius: "24px",
+    screenRadius: "16px",
+    bezelWidth: "10px",
+    padding: "p-4 sm:p-5",
+  },
+  "rounded-60s": {
+    bodyRadius: "18px",
+    screenRadius: "14px",
+    bezelWidth: "8px",
+    padding: "p-3 sm:p-4",
+  },
+  "monitor-90s": {
+    bodyRadius: "18px",
+    screenRadius: "14px",
+    bezelWidth: "8px",
+    padding: "p-3 sm:p-4",
+  },
+} as const;
+
 /**
- * TVShell - The physical CRT television hardware: plastic body, bezel, screen, vents, indicators.
- * All colors use theme tokens so the shell adapts to dark/light mode.
+ * TVShell - The physical CRT television hardware.
+ * Supports era-specific variants that change the shape and decorative details.
+ * Per-TV shell colors can be scoped via the shellStyle prop (sets --crt-shell-* overrides).
  */
 export default function TVShell({
   children,
   className = "",
   brightness = 1,
   intensity = 1,
-  frameClassName = ""
+  frameClassName = "",
+  variant,
+  shellStyle,
 }: TVShellProps) {
+  const config = variant ? VARIANT_CONFIG[variant] : VARIANT_CONFIG["rounded-60s"];
+  const isBoxy = variant === "boxy-80s";
+
   return (
-    <div className={`relative ${className}`}>
+    <div className={`relative ${className}`} style={shellStyle}>
+      {/* Stubby legs — boxy-80s only */}
+      {isBoxy && (
+        <div className="absolute -bottom-3 inset-x-6 flex justify-between pointer-events-none">
+          <div className="w-6 h-3 rounded-b-md bg-crt-shell" style={{ opacity: 0.85 }} />
+          <div className="w-6 h-3 rounded-b-md bg-crt-shell" style={{ opacity: 0.85 }} />
+        </div>
+      )}
+
       {/* Outer CRT body */}
-      <div className={`relative h-full rounded-[18px] shadow-2xl ${frameClassName} bg-crt-shell border border-crt-border-subtle overflow-hidden`}> 
-        {/* Painted plastic shell thickness */}
-        <div className="p-3 sm:p-4 h-full">
+      <div
+        className={`relative h-full shadow-2xl ${frameClassName} bg-crt-shell border border-crt-border-subtle overflow-hidden`}
+        style={{ borderRadius: config.bodyRadius }}
+      >
+        <div className={`${config.padding} h-full`}>
           <div className="flex items-stretch gap-3 h-full">
             {/* Screen with bezel */}
             <div
-              className="relative flex-1 rounded-[14px] bg-crt-shell-screen overflow-hidden"
+              className="relative flex-1 bg-crt-shell-screen overflow-hidden"
               style={{
-                borderWidth: "8px",
+                borderRadius: config.screenRadius,
+                borderWidth: config.bezelWidth,
                 borderStyle: "solid",
                 borderColor: "rgb(var(--crt-shell-bezel) / 0.8)",
                 boxShadow: "inset 0 0 40px rgb(var(--crt-vignette-color) / 0.7)",
               }}
               data-pan-target
             >
-              {/* Actual screen content */}
-              <div 
+              <div
                 className="relative w-full h-full bg-crt-shell-screen"
                 style={{ filter: `brightness(${brightness})`}}
               >
@@ -82,43 +123,58 @@ export default function TVShell({
                   opacity: `var(--crt-bloom-opacity)`,
                 }}
               />
-
             </div>
 
-            {/* Integrated bezel controls along screen edges */}
-            <div className="pointer-events-none absolute inset-0">
-              {/* Right-edge vents */}
-              <div className="absolute right-1 top-4 bottom-4 flex flex-col justify-between">
-                {Array.from({length: 7}).map((_, i) => (
-                  <div key={i} className="w-[3px] h-3 bg-crt-shell-detail rounded-sm" style={{ opacity: 0.8 }} />
-                ))}
+            {/* Channel knobs — boxy-80s only */}
+            {isBoxy && (
+              <div className="flex flex-col items-center justify-center gap-3 w-8 shrink-0">
+                <div
+                  className="w-5 h-5 rounded-full bg-crt-shell-detail border-2"
+                  style={{ borderColor: "rgb(var(--crt-shell-indicator))" }}
+                />
+                <div
+                  className="w-4 h-4 rounded-full bg-crt-shell-detail border-2"
+                  style={{ borderColor: "rgb(var(--crt-shell-indicator))" }}
+                />
               </div>
-
-              {/* Bottom-edge flush indicators */}
-              <div className="absolute inset-x-6 bottom-1 flex items-center justify-center gap-2">
-                {Array.from({length: 5}).map((_, i) => (
-                  <div
-                    key={i}
-                    className="w-2 h-2 rounded-full bg-crt-shell-indicator"
-                    style={{
-                      opacity: 0.9,
-                      boxShadow: "0 0 0 1px rgb(var(--crt-shell-detail))",
-                    }}
-                  />
-                ))}
-              </div>
-
-              {/* Bezel bevel highlights */}
-              <div
-                className="absolute inset-x-0 top-0 h-3"
-                style={{ background: "linear-gradient(to bottom, rgb(var(--crt-glow-color) / 0.1), transparent)" }}
-              />
-              <div
-                className="absolute inset-x-0 bottom-0 h-3"
-                style={{ background: "linear-gradient(to top, rgb(var(--crt-vignette-color) / 0.4), transparent)" }}
-              />
-            </div>
+            )}
           </div>
+        </div>
+
+        {/* Decorative details overlay */}
+        <div className="pointer-events-none absolute inset-0">
+          {/* Right-edge vents (non-boxy variants) */}
+          {!isBoxy && (
+            <div className="absolute right-1 top-4 bottom-4 flex flex-col justify-between">
+              {Array.from({length: 7}).map((_, i) => (
+                <div key={i} className="w-[3px] h-3 bg-crt-shell-detail rounded-sm" style={{ opacity: 0.8 }} />
+              ))}
+            </div>
+          )}
+
+          {/* Bottom-edge indicators */}
+          <div className="absolute inset-x-6 bottom-1 flex items-center justify-center gap-2">
+            {Array.from({length: isBoxy ? 3 : 5}).map((_, i) => (
+              <div
+                key={i}
+                className="w-2 h-2 rounded-full bg-crt-shell-indicator"
+                style={{
+                  opacity: 0.9,
+                  boxShadow: "0 0 0 1px rgb(var(--crt-shell-detail))",
+                }}
+              />
+            ))}
+          </div>
+
+          {/* Bezel bevel highlights */}
+          <div
+            className="absolute inset-x-0 top-0 h-3"
+            style={{ background: "linear-gradient(to bottom, rgb(var(--crt-glow-color) / 0.1), transparent)" }}
+          />
+          <div
+            className="absolute inset-x-0 bottom-0 h-3"
+            style={{ background: "linear-gradient(to top, rgb(var(--crt-vignette-color) / 0.4), transparent)" }}
+          />
         </div>
       </div>
     </div>

--- a/src/components/TVShell.tsx
+++ b/src/components/TVShell.tsx
@@ -20,16 +20,16 @@ const VARIANT_CONFIG = {
     padding: "p-4 sm:p-5",
   },
   "rounded-60s": {
-    bodyRadius: "18px",
-    screenRadius: "14px",
-    bezelWidth: "8px",
-    padding: "p-3 sm:p-4",
+    bodyRadius: "40px",
+    screenRadius: "28px",
+    bezelWidth: "10px",
+    padding: "p-4 sm:p-5",
   },
   "monitor-90s": {
-    bodyRadius: "18px",
-    screenRadius: "14px",
-    bezelWidth: "8px",
-    padding: "p-3 sm:p-4",
+    bodyRadius: "8px",
+    screenRadius: "4px",
+    bezelWidth: "6px",
+    padding: "p-2 sm:p-3",
   },
 } as const;
 
@@ -49,6 +49,8 @@ export default function TVShell({
 }: TVShellProps) {
   const config = variant ? VARIANT_CONFIG[variant] : VARIANT_CONFIG["rounded-60s"];
   const isBoxy = variant === "boxy-80s";
+  const isRounded = variant === "rounded-60s";
+  const isMonitor = variant === "monitor-90s";
 
   return (
     <div className={`relative ${className}`} style={shellStyle}>
@@ -63,7 +65,12 @@ export default function TVShell({
       {/* Outer CRT body */}
       <div
         className={`relative h-full shadow-2xl ${frameClassName} bg-crt-shell border border-crt-border-subtle overflow-hidden`}
-        style={{ borderRadius: config.bodyRadius }}
+        style={{
+          borderRadius: config.bodyRadius,
+          boxShadow: isRounded
+            ? "0 8px 30px rgb(var(--crt-vignette-color) / 0.5), inset 0 2px 4px rgb(var(--crt-glow-color) / 0.1)"
+            : undefined,
+        }}
       >
         <div className={`${config.padding} h-full`}>
           <div className="flex items-stretch gap-3 h-full">
@@ -143,8 +150,38 @@ export default function TVShell({
 
         {/* Decorative details overlay */}
         <div className="pointer-events-none absolute inset-0">
-          {/* Right-edge vents (non-boxy variants) */}
-          {!isBoxy && (
+          {/* Speaker grille — rounded-60s only */}
+          {isRounded && (
+            <div className="absolute inset-x-8 bottom-2 flex items-center justify-center gap-[3px]">
+              {Array.from({length: 12}).map((_, i) => (
+                <div
+                  key={i}
+                  className="w-[2px] h-4 rounded-full bg-crt-shell-detail"
+                  style={{ opacity: 0.5 }}
+                />
+              ))}
+            </div>
+          )}
+
+          {/* Brand strip + power LED — monitor-90s only */}
+          {isMonitor && (
+            <div className="absolute inset-x-3 bottom-1 flex items-center justify-between">
+              <div
+                className="h-[2px] flex-1 rounded-full bg-crt-shell-detail"
+                style={{ opacity: 0.4 }}
+              />
+              <div
+                className="w-2 h-2 rounded-full ml-2 shrink-0"
+                style={{
+                  backgroundColor: "rgb(var(--crt-accent-primary) / 0.7)",
+                  boxShadow: "0 0 4px rgb(var(--crt-accent-primary) / 0.4)",
+                }}
+              />
+            </div>
+          )}
+
+          {/* Right-edge vents (default, non-variant) */}
+          {!isBoxy && !isRounded && !isMonitor && (
             <div className="absolute right-1 top-4 bottom-4 flex flex-col justify-between">
               {Array.from({length: 7}).map((_, i) => (
                 <div key={i} className="w-[3px] h-3 bg-crt-shell-detail rounded-sm" style={{ opacity: 0.8 }} />
@@ -152,19 +189,21 @@ export default function TVShell({
             </div>
           )}
 
-          {/* Bottom-edge indicators */}
-          <div className="absolute inset-x-6 bottom-1 flex items-center justify-center gap-2">
-            {Array.from({length: isBoxy ? 3 : 5}).map((_, i) => (
-              <div
-                key={i}
-                className="w-2 h-2 rounded-full bg-crt-shell-indicator"
-                style={{
-                  opacity: 0.9,
-                  boxShadow: "0 0 0 1px rgb(var(--crt-shell-detail))",
-                }}
-              />
-            ))}
-          </div>
+          {/* Bottom-edge indicators (boxy + default only) */}
+          {!isRounded && !isMonitor && (
+            <div className="absolute inset-x-6 bottom-1 flex items-center justify-center gap-2">
+              {Array.from({length: isBoxy ? 3 : 5}).map((_, i) => (
+                <div
+                  key={i}
+                  className="w-2 h-2 rounded-full bg-crt-shell-indicator"
+                  style={{
+                    opacity: 0.9,
+                    boxShadow: "0 0 0 1px rgb(var(--crt-shell-detail))",
+                  }}
+                />
+              ))}
+            </div>
+          )}
 
           {/* Bezel bevel highlights */}
           <div

--- a/src/components/TVZoomOverlay.tsx
+++ b/src/components/TVZoomOverlay.tsx
@@ -25,8 +25,7 @@ export default function TVZoomOverlay({ selectedItem, onClose, children, backgro
   // ========================================
   // State Management
   // ========================================
-  const [showContent, setShowContent] = useState(false);
-  const [sweepVisible, setSweepVisible] = useState(false);
+  const [phase, setPhase] = useState<"warmup" | "sweep" | "flicker" | "ready" | "off">("off");
   const dialogRef = useRef<HTMLDivElement>(null);
 
   useModalAccessibility({
@@ -36,31 +35,20 @@ export default function TVZoomOverlay({ selectedItem, onClose, children, backgro
     onClose,
   });
 
-  /**
-   * Handle content visibility and sweep animation timing
-   */
   useEffect(() => {
-    if (!selectedItem) return;
+    if (!selectedItem) {
+      setPhase("off");
+      return;
+    }
 
-    // Reset states when new item selected
-    setShowContent(false);
-    setSweepVisible(false);
+    setPhase("warmup");
+    const timers = [
+      setTimeout(() => setPhase("sweep"), 300),
+      setTimeout(() => setPhase("flicker"), 700),
+      setTimeout(() => setPhase("ready"), 850),
+    ];
 
-    // Show content immediately (no static noise delay)
-    const contentTimer = setTimeout(() => {
-      setShowContent(true);
-      setSweepVisible(true);
-    }, 50);
-
-    // Hide sweep after animation completes
-    const sweepTimer = setTimeout(() => {
-      setSweepVisible(false);
-    }, 50 + 400);
-
-    return () => {
-      clearTimeout(contentTimer);
-      clearTimeout(sweepTimer);
-    };
+    return () => timers.forEach(clearTimeout);
   }, [selectedItem]);
 
   return (
@@ -98,42 +86,57 @@ export default function TVZoomOverlay({ selectedItem, onClose, children, backgro
               exit={{ opacity: 0 }}
               transition={{ duration: 0.2 }}
             >
-                {/* Content phase - no static noise, direct transition */}
-                {showContent && (
+                {/* Phase 1: Phosphor warm-up — bright line expands from center */}
+                {phase === "warmup" && (
+                  <div className="absolute inset-0 flex items-center justify-center">
+                    <div
+                      className="w-full"
+                      style={{
+                        height: "2px",
+                        background: "rgb(var(--crt-glow-accent))",
+                        boxShadow: "0 0 20px rgb(var(--crt-glow-accent) / 0.6), 0 0 60px rgb(var(--crt-glow-accent) / 0.3)",
+                        animation: "phosphorWarmup 0.3s ease-out forwards",
+                      }}
+                    />
+                  </div>
+                )}
+
+                {/* Phase 2+: Content with sweep/flicker */}
+                {phase !== "warmup" && phase !== "off" && (
                   <div className="absolute inset-0">
-                    {/* Navigation bar with title and close button */}
                     <Navbar title={selectedItem.title} onClose={onClose} />
 
-                    {/* Page content - initially blurry */}
+                    {/* Page content — blurry during sweep, sharp after */}
                     <div
                       className="absolute inset-0"
                       style={{
-                        filter: sweepVisible ? "blur(2px) brightness(0.8)" : "none"
+                        filter: phase === "sweep" ? "blur(2px) brightness(0.8)" : "none",
+                        animation: phase === "flicker" ? "crtFlicker 0.15s ease-in-out" : undefined,
                       }}
                     >
                       {children}
                     </div>
 
                     {/* Clear content revealed by sweep */}
-                    {sweepVisible && (
+                    {phase === "sweep" && (
                       <div
                         className="absolute inset-0 pointer-events-none"
                         style={{
                           clipPath: "inset(0 0 100% 0)",
-                          animation: "revealClear 0.4s linear forwards"
+                          animation: "revealClear 0.4s linear forwards",
                         }}
                       >
                         <div className="absolute inset-0">{children}</div>
                       </div>
                     )}
 
-                    {/* CRT sweep line - scales with theme glow intensity */}
-                    {sweepVisible && (
+                    {/* Accent-colored sweep line */}
+                    {phase === "sweep" && (
                       <div
                         className="pointer-events-none absolute inset-x-0 h-8 -top-8"
                         style={{
-                          background: "linear-gradient(to bottom, rgb(var(--crt-glow-color) / 0.15), rgb(var(--crt-glow-color) / 0.05), transparent)",
-                          boxShadow: "0 0 20px rgb(var(--crt-glow-color) / 0.3)",
+                          background: "linear-gradient(to bottom, rgb(var(--crt-glow-accent) / 0.2), rgb(var(--crt-glow-accent) / 0.08), transparent)",
+                          boxShadow: "0 0 24px rgb(var(--crt-glow-accent) / 0.4)",
                           opacity: "var(--crt-glow-opacity)",
                           mixBlendMode: "screen",
                           animation: "sweepLine 0.4s linear forwards",
@@ -141,53 +144,47 @@ export default function TVZoomOverlay({ selectedItem, onClose, children, backgro
                       />
                     )}
 
-                    {/* Static noise overlay in unswept area - scales with theme noise intensity */}
-                    {sweepVisible && (
+                    {/* Noise overlay in unswept area */}
+                    {phase === "sweep" && (
                       <div
                         className="pointer-events-none absolute inset-0"
                         style={{
                           opacity: "calc(0.4 * var(--crt-noise-opacity))",
-                          background: `
-                            repeating-linear-gradient(
-                              0deg,
-                              rgb(var(--crt-noise-light) / 0.02) 0px,
-                              rgb(var(--crt-noise-dark) / 0.02) 1px,
-                              transparent 2px,
-                              transparent 3px
-                            ),
-                            repeating-linear-gradient(
-                              90deg,
-                              rgb(var(--crt-noise-light) / 0.01) 0px,
-                              rgb(var(--crt-noise-dark) / 0.01) 1px,
-                              transparent 2px,
-                              transparent 4px
-                            )
-                          `,
+                          background: `repeating-linear-gradient(0deg, rgb(var(--crt-noise-light) / 0.02) 0px, rgb(var(--crt-noise-dark) / 0.02) 1px, transparent 2px, transparent 3px), repeating-linear-gradient(90deg, rgb(var(--crt-noise-light) / 0.01) 0px, rgb(var(--crt-noise-dark) / 0.01) 1px, transparent 2px, transparent 4px)`,
                           clipPath: "inset(0 0 0% 0)",
-                          animation: "hideNoise 0.4s linear forwards"
+                          animation: "hideNoise 0.4s linear forwards",
                         }}
                       />
                     )}
-
-                    {/* Animation keyframes */}
-                    <style>{`
-                      @keyframes sweepLine {
-                        0% { transform: translateY(-150%); }
-                        100% { transform: translateY(calc(100vh + 150%)); }
-                      }
-
-                      @keyframes revealClear {
-                        0% { clip-path: inset(0 0 100% 0); }
-                        100% { clip-path: inset(0 0 0% 0); }
-                      }
-
-                      @keyframes hideNoise {
-                        0% { clip-path: inset(0% 0 0 0); }
-                        100% { clip-path: inset(100% 0 0 0); }
-                      }
-                    `}</style>
                   </div>
                 )}
+
+                <style>{`
+                  @keyframes phosphorWarmup {
+                    0% { transform: scaleY(1); opacity: 0.3; }
+                    50% { transform: scaleY(3); opacity: 1; }
+                    100% { transform: scaleY(100); opacity: 0.8; }
+                  }
+                  @keyframes sweepLine {
+                    0% { transform: translateY(-150%); }
+                    100% { transform: translateY(calc(100vh + 150%)); }
+                  }
+                  @keyframes revealClear {
+                    0% { clip-path: inset(0 0 100% 0); }
+                    100% { clip-path: inset(0 0 0% 0); }
+                  }
+                  @keyframes hideNoise {
+                    0% { clip-path: inset(0% 0 0 0); }
+                    100% { clip-path: inset(100% 0 0 0); }
+                  }
+                  @keyframes crtFlicker {
+                    0% { opacity: 1; }
+                    25% { opacity: 0.7; }
+                    50% { opacity: 1; }
+                    75% { opacity: 0.85; }
+                    100% { opacity: 1; }
+                  }
+                `}</style>
               </motion.div>
             </motion.div>
         </motion.div>

--- a/src/index.css
+++ b/src/index.css
@@ -153,59 +153,59 @@
 .light {
   color-scheme: light;
 
-  /* Backgrounds */
-  --crt-bg-base: 244 244 245;        /* zinc-100 */
-  --crt-bg-elevated: 255 255 255;    /* white */
-  --crt-bg-surface: 250 250 250;     /* zinc-50 */
-  --crt-bg-overlay: 244 244 245;     /* zinc-100 */
+  /* Backgrounds — warm parchment/ivory */
+  --crt-bg-base: 250 246 240;        /* #faf6f0 - warm parchment */
+  --crt-bg-elevated: 255 252 247;    /* warm white */
+  --crt-bg-surface: 246 240 232;     /* warm cream */
+  --crt-bg-overlay: 242 236 226;     /* warm overlay */
 
-  /* Surfaces (cards, panels) */
-  --crt-surface-primary: 241 241 241;  /* warm light gray */
-  --crt-surface-secondary: 228 228 231; /* zinc-200 */
-  --crt-surface-tertiary: 212 212 216; /* zinc-300 */
+  /* Surfaces (cards, panels) — warm-shifted */
+  --crt-surface-primary: 240 234 224;  /* warm light surface */
+  --crt-surface-secondary: 228 220 206; /* warm tan */
+  --crt-surface-tertiary: 214 204 188;  /* warm medium */
 
-  /* Text */
-  --crt-text-primary: 24 24 27;      /* zinc-900 */
-  --crt-text-secondary: 63 63 70;    /* zinc-700 */
-  --crt-text-tertiary: 82 82 91;     /* zinc-600 */
-  --crt-text-muted: 113 113 122;     /* zinc-500 */
+  /* Text — sepia-shifted darks */
+  --crt-text-primary: 38 28 16;      /* warm near-black */
+  --crt-text-secondary: 72 58 40;    /* warm dark brown */
+  --crt-text-tertiary: 102 86 66;    /* warm mid brown */
+  --crt-text-muted: 138 122 100;     /* warm muted */
 
-  /* Borders */
-  --crt-border-primary: 212 212 216;  /* zinc-300 */
-  --crt-border-secondary: 161 161 170; /* zinc-400 */
-  --crt-border-subtle: 228 228 231;  /* zinc-200 */
+  /* Borders — warm-shifted */
+  --crt-border-primary: 210 198 180;  /* warm border */
+  --crt-border-secondary: 180 166 144; /* warm border dark */
+  --crt-border-subtle: 228 220 206;  /* warm border light */
 
-  /* Accent: Primary (deeper for contrast on light bg) */
-  --crt-accent-primary: 8 145 178;     /* cyan-600 */
-  --crt-accent-primary-hover: 6 182 212; /* cyan-500 */
-  --crt-accent-primary-muted: 14 116 144; /* cyan-700 */
-  --crt-accent-primary-deep: 21 94 117;  /* cyan-800 */
+  /* Accent: Primary (deeper amber for contrast on light bg) */
+  --crt-accent-primary: 217 119 6;     /* #d97706 - amber-600 */
+  --crt-accent-primary-hover: 245 158 11; /* amber-500 */
+  --crt-accent-primary-muted: 180 83 9;  /* amber-700 */
+  --crt-accent-primary-deep: 146 64 14;  /* amber-800 */
 
-  /* Accent: Secondary */
-  --crt-accent-secondary: 147 51 234;   /* purple-600 */
-  --crt-accent-secondary-hover: 168 85 247; /* purple-500 */
+  /* Accent: Secondary (deeper teal for contrast) */
+  --crt-accent-secondary: 13 148 136;   /* #0d9488 - teal-600 */
+  --crt-accent-secondary-hover: 20 184 166; /* teal-500 */
 
   /* Semantic accents (deeper for light mode) */
   --crt-accent-info: 37 99 235;       /* blue-600 */
   --crt-accent-info-hover: 59 130 246; /* blue-500 */
   --crt-accent-danger: 220 38 38;     /* red-600 */
-  --crt-accent-warning: 161 98 7;     /* amber-700 - better contrast on light */
-  --crt-accent-success: 21 128 61;    /* green-700 - better contrast on light */
+  --crt-accent-warning: 146 64 14;    /* amber-800 - good contrast on warm bg */
+  --crt-accent-success: 21 128 61;    /* green-700 */
 
-  /* TV Shell (warm beige/gray plastic in daylight) */
-  --crt-shell-body: 200 200 204;     /* warm light plastic */
-  --crt-shell-bezel: 161 161 170;    /* zinc-400 */
-  --crt-shell-screen: 240 240 243;    /* light screen for readability */
-  --crt-shell-detail: 113 113 122;   /* zinc-500 */
-  --crt-shell-indicator: 82 82 91;   /* zinc-600 */
+  /* TV Shell — warm sepia/tan plastic in daylight */
+  --crt-shell-body: 198 182 158;     /* warm tan plastic */
+  --crt-shell-bezel: 158 140 116;    /* sepia bezel */
+  --crt-shell-screen: 238 232 222;   /* warm light screen */
+  --crt-shell-detail: 138 122 100;   /* warm bronze detail */
+  --crt-shell-indicator: 102 86 66;  /* warm dark indicator */
 
   /* CRT Effects (subdued in bright room) */
-  --crt-glow-color: 0 0 0;           /* inverted: dark glow on light */
-  --crt-glow-accent: 8 145 178;      /* cyan-600 */
-  --crt-scanline-color: 0 0 0;       /* dark scanlines on light screen */
-  --crt-vignette-color: 0 0 0;       /* still dark vignette */
-  --crt-noise-light: 0 0 0;          /* inverted noise */
-  --crt-noise-dark: 255 255 255;     /* inverted noise */
+  --crt-glow-color: 38 28 16;        /* warm dark glow on light */
+  --crt-glow-accent: 217 119 6;      /* amber-600 */
+  --crt-scanline-color: 38 28 16;    /* warm dark scanlines */
+  --crt-vignette-color: 38 28 16;    /* warm dark vignette */
+  --crt-noise-light: 38 28 16;       /* warm inverted noise */
+  --crt-noise-dark: 250 246 240;     /* warm inverted noise */
 
   /* CRT Effect Intensities (subdued for bright room) */
   --crt-scanline-opacity: 0.5;
@@ -214,9 +214,9 @@
   --crt-glow-opacity: 0.3;
   --crt-bloom-opacity: 0.4;
 
-  /* Gradient endpoints */
-  --crt-gradient-from: 8 145 178;    /* cyan-600 */
-  --crt-gradient-to: 147 51 234;     /* purple-600 */
+  /* Gradient endpoints — amber to teal */
+  --crt-gradient-from: 217 119 6;    /* amber-600 */
+  --crt-gradient-to: 13 148 136;     /* teal-600 */
 }
 
 /* ========================================

--- a/src/index.css
+++ b/src/index.css
@@ -81,59 +81,59 @@
 :root {
   color-scheme: dark;
 
-  /* Backgrounds */
-  --crt-bg-base: 0 0 0;             /* #000000 - deep black */
-  --crt-bg-elevated: 24 24 27;      /* zinc-900 */
-  --crt-bg-surface: 17 17 17;       /* near-black surface */
-  --crt-bg-overlay: 0 0 0;          /* overlay base */
+  /* Backgrounds — warm brown-black instead of pure black */
+  --crt-bg-base: 26 18 8;           /* #1a1208 - deep warm brown-black */
+  --crt-bg-elevated: 36 28 18;      /* warm dark brown */
+  --crt-bg-surface: 30 22 12;       /* near-black with brown undertone */
+  --crt-bg-overlay: 20 14 6;        /* overlay base */
 
-  /* Surfaces (cards, panels) */
-  --crt-surface-primary: 23 23 23;   /* gray-900 equivalent */
-  --crt-surface-secondary: 38 38 38; /* gray-800 equivalent */
-  --crt-surface-tertiary: 50 50 50;  /* gray-700 equivalent */
+  /* Surfaces (cards, panels) — warm-shifted grays */
+  --crt-surface-primary: 34 26 16;   /* warm dark surface */
+  --crt-surface-secondary: 48 38 26; /* warm mid surface */
+  --crt-surface-tertiary: 62 50 36;  /* warm light surface */
 
-  /* Text */
-  --crt-text-primary: 255 255 255;   /* white */
-  --crt-text-secondary: 209 213 219; /* gray-300 */
-  --crt-text-tertiary: 156 163 175;  /* gray-400 */
-  --crt-text-muted: 107 114 128;     /* gray-500 */
+  /* Text — warm off-white instead of pure white */
+  --crt-text-primary: 245 240 232;   /* #f5f0e8 - warm off-white */
+  --crt-text-secondary: 214 204 188; /* warm gray-300 */
+  --crt-text-tertiary: 168 156 138;  /* warm gray-400 */
+  --crt-text-muted: 122 112 98;      /* warm gray-500 */
 
-  /* Borders */
-  --crt-border-primary: 63 63 70;    /* zinc-700 */
-  --crt-border-secondary: 82 82 91;  /* zinc-600 */
-  --crt-border-subtle: 39 39 42;     /* zinc-800 */
+  /* Borders — brown-shifted */
+  --crt-border-primary: 72 60 44;    /* warm border */
+  --crt-border-secondary: 92 78 58;  /* warm border light */
+  --crt-border-subtle: 46 36 24;     /* warm border dark */
 
-  /* Accent: Primary (phosphor green-cyan glow) */
-  --crt-accent-primary: 34 211 238;    /* cyan-400 */
-  --crt-accent-primary-hover: 103 232 249; /* cyan-300 */
-  --crt-accent-primary-muted: 8 145 178;  /* cyan-600 */
-  --crt-accent-primary-deep: 14 116 144;  /* cyan-700 */
+  /* Accent: Primary (amber-orange phosphor glow) */
+  --crt-accent-primary: 245 158 11;     /* #f59e0b - amber-500 */
+  --crt-accent-primary-hover: 252 191 73; /* amber-300 */
+  --crt-accent-primary-muted: 217 119 6;  /* #d97706 - amber-600 */
+  --crt-accent-primary-deep: 180 83 9;    /* amber-700 */
 
-  /* Accent: Secondary (phosphor purple) */
-  --crt-accent-secondary: 192 132 252;   /* purple-400 */
-  --crt-accent-secondary-hover: 216 180 254; /* purple-300 */
+  /* Accent: Secondary (teal-green modern pop) */
+  --crt-accent-secondary: 45 212 191;   /* #2dd4bf - teal-400 */
+  --crt-accent-secondary-hover: 94 234 212; /* teal-300 */
 
   /* Semantic accents */
   --crt-accent-info: 96 165 250;     /* blue-400 */
   --crt-accent-info-hover: 147 197 253; /* blue-300 */
-  --crt-accent-danger: 239 68 68;    /* red-500 */
-  --crt-accent-warning: 250 204 21;  /* yellow-400 */
+  --crt-accent-danger: 248 113 113;  /* red-400 */
+  --crt-accent-warning: 252 211 77;  /* amber-300 */
   --crt-accent-success: 74 222 128;  /* green-400 */
 
-  /* TV Shell (the physical hardware) */
-  --crt-shell-body: 63 63 70;       /* zinc-700 */
-  --crt-shell-bezel: 24 24 27;      /* zinc-900 */
-  --crt-shell-screen: 9 9 11;       /* zinc-950 */
-  --crt-shell-detail: 113 113 122;  /* zinc-500 */
-  --crt-shell-indicator: 161 161 170; /* zinc-400 */
+  /* TV Shell — warm walnut brown default */
+  --crt-shell-body: 107 76 42;      /* #6b4c2a - walnut brown */
+  --crt-shell-bezel: 61 43 20;      /* #3d2b14 - dark walnut */
+  --crt-shell-screen: 16 12 6;      /* near-black warm */
+  --crt-shell-detail: 138 114 82;   /* warm bronze */
+  --crt-shell-indicator: 180 156 120; /* warm brass */
 
-  /* CRT Effects (glow, scanlines, vignette) */
-  --crt-glow-color: 255 255 255;     /* white glow */
-  --crt-glow-accent: 34 211 238;     /* cyan glow for accented elements */
-  --crt-scanline-color: 255 255 255;  /* white scanlines */
-  --crt-vignette-color: 0 0 0;       /* black vignette */
-  --crt-noise-light: 255 255 255;    /* noise bright */
-  --crt-noise-dark: 0 0 0;           /* noise dark */
+  /* CRT Effects — warm amber glow */
+  --crt-glow-color: 255 241 214;     /* warm white glow */
+  --crt-glow-accent: 245 158 11;     /* amber glow */
+  --crt-scanline-color: 255 241 214;  /* warm scanlines */
+  --crt-vignette-color: 10 6 2;      /* deep warm vignette */
+  --crt-noise-light: 255 241 214;    /* warm noise bright */
+  --crt-noise-dark: 10 6 2;          /* warm noise dark */
 
   /* CRT Effect Intensities (multipliers for dark room) */
   --crt-scanline-opacity: 1;
@@ -142,9 +142,9 @@
   --crt-glow-opacity: 1;
   --crt-bloom-opacity: 1;
 
-  /* Gradient endpoints */
-  --crt-gradient-from: 34 211 238;   /* cyan-400 */
-  --crt-gradient-to: 192 132 252;    /* purple-400 */
+  /* Gradient endpoints — amber to teal */
+  --crt-gradient-from: 245 158 11;   /* amber-500 */
+  --crt-gradient-to: 45 212 191;     /* teal-400 */
 }
 
 /* ========================================

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -33,10 +33,13 @@ export interface PanState {
 }
 
 // TV configuration
+export type TVVariant = "boxy-80s" | "rounded-60s" | "monitor-90s";
+
 export interface TVConfig {
   id: string;
   title: string;
   width: number;
+  variant?: TVVariant;
 }
 
 // Navigation function type


### PR DESCRIPTION
## Summary

- Make TV sizing responsive across mobile, tablet, desktop, and ultrawide
- Cap stage width at 1600px for ultrawide monitors
- Scale gaps and text size per breakpoint

## What I Learned

### Responsive clamp() with Tailwind Breakpoints
The TV width uses `clamp()` inside arbitrary Tailwind values at each breakpoint:
- `w-[clamp(14rem,70vw,18rem)]` — mobile: takes up most of the screen width
- `sm:w-[clamp(12rem,30vw,16rem)]` — small tablet: shrinks to fit 2-3 TVs
- `md:w-[clamp(14rem,24vw,20rem)]` — desktop: the original comfortable size
- `lg:w-[clamp(16rem,20vw,22rem)]` — large screens: grows a bit with more spacing

`clamp(min, preferred, max)` gives fluid scaling within each breakpoint range, so the TVs don't jump sizes abruptly at breakpoint boundaries.

### Column vs Row Breakpoint
PanStage now switches from column to row at `sm` (640px) instead of `md` (768px). This means two TVs side-by-side become visible earlier on tablets. The gap also scales: 4→6→8→10 across breakpoints so spacing feels proportional.

### Ultrawide Capping
`max-w-[1600px]` on the stage container prevents TVs from spreading too far apart on 3440px+ monitors. Without this, the `vw`-based sizing would make TVs uncomfortably large and widely spaced.

## Changes

| File | Change |
|---|---|
| `src/App.tsx` | Responsive TV width clamp values, max-w-[1600px], px-4/8, text size scaling |
| `src/components/PanStage.tsx` | Row layout at sm, responsive gap scaling |

## Verification

- `bun run build` passes


Made with [Cursor](https://cursor.com)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add responsive TV stage layout with era-specific hardware variants and warm amber theme
> - [TVShell.tsx](https://github.com/EricsenSemedo/crt-portfolio/pull/40/files#diff-09b64dc7c1e737c1369d710328c5dbcfe4ccf358e1de3811a322968de5736b00) gains a `variant` prop (`boxy-80s`, `rounded-60s`, `monitor-90s`) that renders distinct CRT shapes, bezels, and decorative elements (legs, knobs, speaker grilles, brand strips) per era
> - [App.tsx](https://github.com/EricsenSemedo/crt-portfolio/pull/40/files#diff-26ad4b834941d9b19ebf9db8082bd202aaf72ea0ddea85f5a8a0cb3c729cc6f2) assigns a variant to each TV and applies responsive sizing/padding classes across breakpoints; [PanStage.tsx](https://github.com/EricsenSemedo/crt-portfolio/pull/40/files#diff-bcd7c8d92098b6fce86c363cf2ac49145d192be7b616230b82c25a451130c3ea) switches to row layout at the `sm` breakpoint with scaled gap sizes
> - [TVZoomOverlay.tsx](https://github.com/EricsenSemedo/crt-portfolio/pull/40/files#diff-e72cc239a5dfdf1789366fffd82c7672f61332f6b9bbe244c1cbdf18f8a7fa5e) replaces a two-state boolean with a four-phase state machine (`warmup → sweep → flicker → ready`) for a phosphor warm-up and flicker animation on TV selection
> - [index.css](https://github.com/EricsenSemedo/crt-portfolio/pull/40/files#diff-85da366246340e911d7a0eb9153e64137a1b31f0686c74d9aef9ae4f032cb09e) overhauls all theme CSS variables to a warm amber/teal palette for both dark and light modes, affecting every component that consumes these variables
> - Behavioral Change: `howler`/`@types/howler` are removed from dependencies; the overlay transition sequence is now longer due to the added warm-up and flicker phases
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 7872973.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->