### PR TITLE
chore: apply optimize-context-files audit to AGENTS.md and PRD.md

### DIFF
--- a/.cursor/rules/tsx-standards.mdc
+++ b/.cursor/rules/tsx-standards.mdc
@@ -1,0 +1,11 @@
+---
+description: "React/TypeScript code standards for CRT Portfolio"
+globs: ["**/*.tsx", "**/*.ts"]
+alwaysApply: false
+---
+
+- Function declarations for components, not arrow functions: `export default function Name(...)`.
+- No enums — use string literal unions.
+- No clsx — use string concatenation for conditional classes.
+- Inline `type` keyword in imports: `import { useState, type ReactNode } from "react"`.
+- Relative imports only — `@/*` alias exists in tsconfig but is unused.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,6 @@
 # CRT Portfolio
 
-Retro CRT television portfolio site. React 19, TypeScript, Vite 7, Tailwind CSS v4, Framer Motion v12. Deployed to GitHub Pages at `/crt-portfolio/`.
+Retro CRT television portfolio site. Frontend-only SPA deployed to GitHub Pages at `/crt-portfolio/`.
 
 ## Core Priorities
 
@@ -26,13 +26,10 @@ Type-check without building: `bunx tsc --noEmit`
 
 ## Non-obvious conventions
 
+TypeScript/React-specific rules live in `.cursor/rules/tsx-standards.mdc` (auto-attaches when editing `*.ts` / `*.tsx`). Project-wide:
+
 - **No Prettier.** Semicolons are inconsistent across files — match the file you're editing.
-- **Relative imports only.** `@/*` alias exists in tsconfig but is unused — stay consistent with relative paths.
-- **Function declarations** for components, not arrow functions: `export default function Name(...)`.
-- **No enums.** Use string literal unions.
-- **No clsx.** Use string concatenation for conditional classes.
 - **No external state library.** `useState`/`useRef` only.
-- **Inline `type` keyword** in imports: `import { useState, type ReactNode } from "react"`.
 
 ## PRs
 

--- a/PRD.md
+++ b/PRD.md
@@ -46,43 +46,20 @@ interaction design skills while presenting project work.
 
 ## Architecture
 
-```
-index.html
-  └─ main.tsx
-      └─ ThemeProvider (context: theme, toggleTheme, setTheme)
-          └─ App
-              ├─ ThemeToggle (fixed position, bottom-right)
-              ├─ ParallaxBackground (mouse-tracking spring offset)
-              │   └─ PanStage (camera: translate/scale via Framer Motion controls)
-              │       └─ TVShell x3 (Home, Portfolio, Contact)
-              │           └─ StaticNoise (idle state)
-              └─ TVZoomOverlay (when selectedId && !isAnimating)
-                  ├─ Navbar (title + close button)
-                  ├─ CRTScanlines + CRTVignette
-                  └─ Page content (Home | Portfolio | Contact)
-                      └─ Portfolio ─→ ProjectDetailView (nested modal)
-```
+Component tree, key patterns, and module responsibilities are discoverable from `src/` —
+start at `src/main.tsx` → `src/App.tsx` → follow imports. Conventions worth flagging that
+are NOT obvious from reading code:
 
-### Key Patterns
-
-- **Camera system (PanStage):** Imperative API via `forwardRef` + `useImperativeHandle`.
-  Exposes `reset()`, `centerOn()`, `selectTV()`. Manages camera transform (x, y, scale)
-  with ref-backed state to avoid stale closures. Different animation configs for zoom-in
-  (tween) vs. zoom-out (spring). Firefox Mobile fallback uses CSS transitions instead of
-  Framer Motion.
-
-- **Modal stack (useModalAccessibility):** Custom hook managing focus trap, Escape key,
-  `inert`/`aria-hidden` on background, and an `activeModalStack` array for nested modals
-  (TVZoomOverlay > ProjectDetailView).
-
-- **Theme system:** CSS custom properties with `rgb(var(--token))` pattern for
-  alpha-composable colors. Tailwind v4 `@theme` directive maps tokens to utility classes.
-  `ThemeProvider` with localStorage persistence. `applyTheme` uses View Transitions API
-  with CSS transition-class fallback.
-
-- **CRT effects:** Composable overlay components (CRTScanlines, CRTVignette, StaticNoise)
-  with intensity props. Effect opacities multiply with CSS variable multipliers
-  (`--crt-scanline-opacity`, etc.) that differ between dark (1.0) and light (0.4–0.6) themes.
+- **Theme intensity multipliers:** CRT effect opacities multiply by CSS vars
+  (`--crt-scanline-opacity`, `--crt-vignette-opacity`, `--crt-noise-opacity`) that differ
+  between dark (1.0) and light (0.4–0.6) modes. Tweaking a single component's opacity
+  without going through these tokens will desync theme parity.
+- **Firefox Mobile fallback in PanStage:** UA-sniffed CSS transitions are used instead of
+  Framer Motion controls because the `transform` interpolation jitters on FF mobile. Don't
+  remove the branch without testing on real device.
+- **Modal stack ordering:** `activeModalStack` in `useModalAccessibility` enforces
+  TVZoomOverlay > ProjectDetailView. Adding a new modal requires registering it in the
+  stack so `inert`/focus-restore work correctly.
 
 ## Task Tracker
 


### PR DESCRIPTION
## Summary

Applied the optimize-context-files skill (added in #42) to slim project context files based on the arXiv:2602.11988 framework. The research finding: developer-written context files give +4% task success but cost ~20% more in inference, mostly from overviews that agents don't act on.

> **Stacked on #42** — skill itself is added there.

## Audit results

| File | Before | After | Delta | Action |
|---|---:|---:|---:|---|
| AGENTS.md | 50 | 47 | -3 | Dropped tech-stack versions (in package.json), moved TS-specific rules to scoped Cursor rule |
| PRD.md | 157 | 134 | -23 | Removed architecture tree (agent walks src/), trimmed Key Patterns to only non-obvious gotchas |
| LEARNING.md | 93 | 93 | 0 | Untouched — used directly by `learn` skill |
| .cursor/rules/tsx-standards.mdc | — | 11 | +11 | NEW — globs to `*.ts`/`*.tsx`, doesn't load on non-code chats |

Net: **-15 lines** in always-loaded context, plus **11 lines** behind a glob (loads only when editing TS files).

## What I kept and why

- **Core Priorities + Maintainability** — non-obvious agent direction (performance/reliability over convenience)
- **Commands table** — niche tool (bun) and project-specific scripts
- **Cursor Cloud instructions** — base-path gotcha (`/crt-portfolio/`) is machine-specific and not discoverable from code
- **PR conventions** — guides PR creation
- **Living Documents pointers** (4 lines) — signals to fresh sessions that LEARNING.md exists for the `learn` skill

## What I removed and why

- **Architecture tree diagram** — agent walks `src/main.tsx → App.tsx → imports` in one read; tree just duplicates that
- **"Key Patterns" prose** (camera system, modal stack, theme system, CRT effects) — all of this is discoverable by reading the components themselves; prose was paraphrasing the code
- **Tech stack line in AGENTS.md** — `package.json` is canonical for versions
- **TypeScript/React conventions in AGENTS.md** — moved to scoped Cursor rule that fires only when those files are open

## What I added (and the trade-off it makes)

`.cursor/rules/tsx-standards.mdc` with `globs: ["**/*.tsx","**/*.ts"]` and `alwaysApply: false`. This means the rule loads only when a TS/TSX file is in context, saving tokens on docs/config conversations.

**Trade-off**: agents asked about these conventions in a pure-chat context (no code files open) won't see them. Acceptable because the conventions are about *editing* TS files — the rule fires exactly when needed.

## Verification

- `bun run build` passes (production build unaffected — context files are docs)
- `bunx tsc --noEmit` passes
- No source code changes

## What I might not know

- Whether Cursor v2 honors the `globs` field exactly as v1 did. If a future Cursor release changes glob semantics, the rule may load more or less often than intended.
- Whether the `learn` skill explicitly looks for LEARNING.md by filename. If it doesn't, the AGENTS.md pointer is the only signal — keep it.

Made with [Cursor](https://cursor.com)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Consolidate TypeScript/React coding conventions into a dedicated Cursor rules file
> - Adds [tsx-standards.mdc](.cursor/rules/tsx-standards.mdc) to capture TS/React-specific rules: function declarations for components, string literal unions over enums, string concatenation over `clsx`, inline `type` imports, and relative imports only.
> - Updates [AGENTS.md](AGENTS.md) to remove the now-duplicated TS/React bullets and point to the new rules file; project-wide conventions (no Prettier, no external state library) are retained.
> - Reworks the Architecture section of [PRD.md](PRD.md) to drop the explicit component tree and replace it with pointers to `src/` entry points and a short list of non-obvious conventions (CSS var intensity multipliers, Firefox Mobile fallback in `PanStage`, modal stack ordering).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 09a3b06.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->