### PR TITLE
feat: global keyboard shortcuts for TV navigation

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,10 +1,11 @@
-import { useEffect, useMemo, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import PanStage, { type PanStageRef } from "./components/PanStage";
 import ParallaxBackground from "./components/ParallaxBackground";
 import StaticNoise from "./components/StaticNoise";
 import ThemeToggle from "./components/ThemeToggle";
 import TVShell from "./components/TVShell";
 import TVZoomOverlay from "./components/TVZoomOverlay";
+import { useKeyboardNav } from "./hooks/useKeyboardNav";
 import Contact from "./pages/Contact";
 import Home from "./pages/Home";
 import Portfolio from "./pages/Portfolio";
@@ -54,7 +55,7 @@ export default function App() {
     }
   }, [panState.selectedId, panState.isAnimating, pendingNavigation]);
 
-  const navigateToTV = (targetId: string) => {
+  const navigateToTV = useCallback((targetId: string) => {
     if (!panRef.current || targetId === panState.selectedId) return;
 
     if (panState.selectedId) {
@@ -63,7 +64,16 @@ export default function App() {
     } else {
       panRef.current.selectTV(targetId);
     }
-  };
+  }, [panState.selectedId]);
+
+  const tvIds = useMemo(() => TVs.map((tv) => tv.id), [TVs]);
+
+  useKeyboardNav({
+    tvIds,
+    selectedId: panState.selectedId,
+    isAnimating: panState.isAnimating,
+    onNavigate: navigateToTV,
+  });
 
   // ========================================
   // Page Content Mapping

--- a/src/hooks/useKeyboardNav.ts
+++ b/src/hooks/useKeyboardNav.ts
@@ -1,0 +1,87 @@
+import { useEffect } from "react";
+
+interface UseKeyboardNavOptions {
+  tvIds: readonly string[];
+  selectedId: string | null;
+  isAnimating: boolean;
+  onNavigate: (id: string) => void;
+}
+
+const DIGIT_KEYS = ["1", "2", "3", "4", "5", "6", "7", "8", "9"] as const;
+
+function isTypingTarget(target: EventTarget | null): boolean {
+  if (!(target instanceof HTMLElement)) return false;
+  const tag = target.tagName;
+  if (tag === "INPUT" || tag === "TEXTAREA" || tag === "SELECT") return true;
+  if (target.isContentEditable) return true;
+  return false;
+}
+
+/**
+ * Global keyboard shortcuts for TV channel navigation.
+ *
+ * - 1-9 / Digit1-Digit9: jump directly to the TV at that index
+ * - ArrowLeft / ArrowRight (and KeyH/KeyL): cycle to previous/next TV
+ *
+ * Skips when the user is typing in a form field, while a camera animation is
+ * in flight (prevents queuing during the zoom transition), or when modifier
+ * keys are held (so browser/OS shortcuts like Cmd+1 still work).
+ *
+ * Escape is intentionally NOT handled here — useModalAccessibility owns that
+ * key and uses capture-phase + stopPropagation to close the topmost dialog.
+ */
+export function useKeyboardNav({
+  tvIds,
+  selectedId,
+  isAnimating,
+  onNavigate,
+}: UseKeyboardNavOptions) {
+  useEffect(() => {
+    function handleKeyDown(event: KeyboardEvent) {
+      if (event.metaKey || event.ctrlKey || event.altKey) return;
+      if (isTypingTarget(event.target)) return;
+      if (isAnimating) return;
+      if (tvIds.length === 0) return;
+
+      // Direct selection by index (1-9). event.code handles non-US layouts
+      // where event.key may be a different glyph for the same physical row.
+      const digitFromCode = event.code.startsWith("Digit") ? event.code.slice(5) : null;
+      const digit = digitFromCode && DIGIT_KEYS.includes(digitFromCode as (typeof DIGIT_KEYS)[number])
+        ? digitFromCode
+        : DIGIT_KEYS.includes(event.key as (typeof DIGIT_KEYS)[number])
+          ? event.key
+          : null;
+
+      if (digit) {
+        const index = Number(digit) - 1;
+        const targetId = tvIds[index];
+        if (targetId && targetId !== selectedId) {
+          event.preventDefault();
+          onNavigate(targetId);
+        }
+        return;
+      }
+
+      const goPrevious = event.key === "ArrowLeft" || event.code === "KeyH";
+      const goNext = event.key === "ArrowRight" || event.code === "KeyL";
+
+      if (goPrevious || goNext) {
+        const delta = goNext ? 1 : -1;
+        const currentIndex = selectedId ? tvIds.indexOf(selectedId) : -1;
+        // Decision: when nothing is selected, ArrowRight enters at index 0 and
+        // ArrowLeft enters at the last TV. This mirrors how a remote channel
+        // up/down behaves when the TV is "off".
+        const startIndex = currentIndex === -1 ? (delta > 0 ? -1 : 0) : currentIndex;
+        const nextIndex = (startIndex + delta + tvIds.length) % tvIds.length;
+        const targetId = tvIds[nextIndex];
+        if (targetId && targetId !== selectedId) {
+          event.preventDefault();
+          onNavigate(targetId);
+        }
+      }
+    }
+
+    window.addEventListener("keydown", handleKeyDown);
+    return () => window.removeEventListener("keydown", handleKeyDown);
+  }, [tvIds, selectedId, isAnimating, onNavigate]);
+}


### PR DESCRIPTION
## Summary

Adds remote-control-style keyboard navigation across the whole app. You called this out as the next thing to pick up after the responsive layout work — this lays the foundation that the upcoming **navbar polish** PR will visualize with on-screen hints.

> **Stacked on #41** (feat/responsive-page-content) so it picks up the latest UI

## What this gives you

| Key | Action |
|---|---|
| `1`, `2`, `3` | Jump to Home / Portfolio / Contact |
| `ArrowLeft` | Previous TV (cycles) |
| `ArrowRight` | Next TV (cycles) |
| `H` / `L` | vim-style aliases for prev/next |
| `Esc` | Close current TV (already wired via useModalAccessibility) |

When nothing is selected, `ArrowRight` enters at the first TV and `ArrowLeft` enters at the last — channel-up/channel-down behavior.

## What I learned (and what to look at)

### Hook composition over ad-hoc listeners
Putting all keyboard shortcuts in a single `useKeyboardNav` hook means there's exactly one place to look for "what does this key do?" If a future PR adds, say, `?` to toggle keyboard hints, that goes here. Spreading listeners across components is how you end up with shortcuts that fight each other.

### `event.code` vs `event.key`
```ts
const digitFromCode = event.code.startsWith("Digit") ? event.code.slice(5) : null;
```
`event.key` is the printed character (locale-dependent — `1` on US, `&` on AZERTY when no shift is held). `event.code` is the physical key position. For "1/2/3 jump to TV index" you want the position, not the glyph. We fall back to `event.key` so virtual keyboards still work.

### Why `useCallback` on navigateToTV
Before this PR, `navigateToTV` was a fresh function on every render. The hook's `useEffect` would tear down and re-bind the window listener every render — wasteful, and a subtle source of dropped events if a key fires during the gap. Memoizing it with `useCallback` keeps the listener stable.

### Escape is intentionally not handled here
`useModalAccessibility` already owns Escape via `document.addEventListener("keydown", handler, true)` — capture-phase with `stopPropagation()`. If I duplicated Escape here, it would be intercepted whenever a modal is open. The single owner avoids the modal-stack double-fire problem (TVZoomOverlay > ProjectDetailView).

## Decision

- **Why this approach**: a single window-scoped hook keeps shortcut behavior centralized, testable, and easy to extend
- **Alternatives considered**: per-component listeners (rejected — fragments shortcut policy), routing library with declarative bindings (rejected — overkill for 3 destinations and the project's "no external state library" rule)
- **Tradeoffs**: shortcuts only work when window has focus (iframes/devtools-focus break them — same as every web app)
- **Unknowns**: whether some users expect `Tab` to also cycle TVs from the overview screen. Today Tab follows the TV grid's natural focus order via `tabIndex={0}` on each TV in `PanStage`, which I think is the right default — happy to revisit if it feels off.

## Verification

- `bun run build` passes
- `bunx tsc --noEmit` clean
- No new lint errors

## Test plan

- [ ] Press `1`, `2`, `3` from the overview — each opens the right TV
- [ ] Press `1` from inside the Home TV — no-op (already selected)
- [ ] Press `2` from inside Home — Home zooms out, then Portfolio zooms in
- [ ] Press `ArrowRight` repeatedly — cycles Home → Portfolio → Contact → Home
- [ ] Focus the contact form (if any input is present) and type — shortcuts don't fire
- [ ] `Cmd+1` / `Ctrl+1` reaches the browser (does not open a TV)

Made with [Cursor](https://cursor.com)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add global keyboard shortcuts for TV navigation
> - Adds a [`useKeyboardNav`](https://github.com/EricsenSemedo/crt-portfolio/pull/44/files#diff-cdc3a198a8bcced35a9668058886384e65fc7343e5def8e43282ae5ef03ac9c5) hook that registers a `window` keydown listener to navigate between TVs using digit keys (1–9) for direct index selection and ArrowLeft/H / ArrowRight/L for cyclic previous/next.
> - Wires the hook into [`App.tsx`](https://github.com/EricsenSemedo/crt-portfolio/pull/44/files#diff-26ad4b834941d9b19ebf9db8082bd202aaf72ea0ddea85f5a8a0cb3c729cc6f2) by passing the memoized `tvIds` list, current `selectedId`, animation state, and `navigateToTV` callback.
> - Shortcuts are suppressed when modifier keys (meta/ctrl/alt) are held, when the user is typing in an input/textarea/select/contentEditable, or while an animation is in progress.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 188aaa1.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->