### PR TITLE
chore: gitignore personal context skills (me)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,8 @@ dist-ssr
 .cursor/*
 !.cursor/rules/
 .cursorrules
+
+# Personal context skills (per-user, copied from owner's Obsidian vault)
+# Source of truth: ~/Documents/ObsidianVault/my_2nd_brain/skills/
+.agents/skills/me/
+.claude/skills/me


### PR DESCRIPTION
## Summary

Replaces #45 (now closed). Instead of committing the `me` skill into the repo, this just adds the paths to `.gitignore` so the skill works locally without ever being tracked.

## Why

The `me` skill is per-user — it pulls from your private `ME.md` and project `LEARNING.md` to calibrate explanations to a specific person. That doesn't belong in a public repo, and it definitely shouldn't be shared with hypothetical future contributors (each one would install their own from their own vault).

## What's actually in this PR

```diff
+ # Personal context skills (per-user, copied from owner's Obsidian vault)
+ # Source of truth: ~/Documents/ObsidianVault/my_2nd_brain/skills/
+ .agents/skills/me/
+ .claude/skills/me
```

Five lines in `.gitignore`. That's it.

## Decision

- **Why ignore the specific paths**: explicit, greppable, narrow. If you ever add a different shared skill named `me`, you'll notice immediately.
- **Alternatives considered**: a broader convention like `.agents/skills/private/*` or a `*.private` suffix — rejected as premature abstraction for exactly one personal skill today. Easy to refactor later if more personal skills appear.
- **Tradeoffs**: anyone cloning this repo won't get the `me` skill. Intentional — they should install their own from their own vault.
- **Unknowns**: whether the comment in `.gitignore` referencing `~/Documents/ObsidianVault/...` is too prescriptive (it's your specific path). Acceptable since this is a single-owner project; if collaborators ever join, the comment can soften to just "your personal knowledge base."

## Verification

- `me` skill files are restored locally from the vault and `git status` confirms they're properly ignored
- `.claude/skills/` lists `me` alongside the others, so the skill is loadable
- `bun run build` unaffected (skills live outside `src/`)

Made with [Cursor](https://cursor.com)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Ignore personal context skills directories in git
> Adds `.agents/skills/me/` and `.claude/skills/me` to [.gitignore](https://github.com/EricsenSemedo/crt-portfolio/pull/46/files#diff-bc37d034bad564583790a46f19d807abfe519c5671395fd494d8cce506c42947) to prevent personal context skills from being committed to the repository.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 1d2189a.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->